### PR TITLE
chores: remove file cleanup step

### DIFF
--- a/retrieval_service/alloydb.tests.cloudbuild.yaml
+++ b/retrieval_service/alloydb.tests.cloudbuild.yaml
@@ -90,16 +90,6 @@ steps:
         diff --strip-trailing-cr -Z amenity_dataset.csv amenity_dataset.csv.new || (echo "amenity dataset export fail" && exit 1)
         diff --strip-trailing-cr -Z flights_dataset.csv flights_dataset.csv.new || (echo "flight dataset export fail" && exit 1)
 
-  - id: Clean exported files
-    name: python:3.11
-    dir: data
-    entrypoint: /bin/bash
-    args:
-      - "-c"
-      - |
-        rm airport_dataset.csv.new amenity_dataset.csv.new flights_dataset.csv.new
-
-
   - id: Clean database
     name: postgres
     entrypoint: /bin/bash


### PR DESCRIPTION
Since it's not stored in Google (like in Cloud Storage or another service), it will be cleaned up automatically after the test run.