### PR TITLE
chores: update search flight sql

### DIFF
--- a/retrieval_service/datastore/providers/cloudsql_postgres.py
+++ b/retrieval_service/datastore/providers/cloudsql_postgres.py
@@ -418,7 +418,7 @@ class Client(datastore.Client[Config]):
                 SELECT * FROM flights
                   WHERE (CAST(:departure_airport AS TEXT) IS NULL OR departure_airport ILIKE :departure_airport)
                   AND (CAST(:arrival_airport AS TEXT) IS NULL OR arrival_airport ILIKE :arrival_airport)
-                  AND departure_time > CAST(:datetime AS timestamp) - interval '1 day'
+                  AND departure_time >= CAST(:datetime AS timestamp)
                   AND departure_time < CAST(:datetime AS timestamp) + interval '1 day'
                 """
             )

--- a/retrieval_service/datastore/providers/firestore.py
+++ b/retrieval_service/datastore/providers/firestore.py
@@ -246,8 +246,8 @@ class Client(datastore.Client[Config]):
         date_timestamp = datetime.combine(date_obj, datetime.min.time())
         query = (
             self.__client.collection("flights")
-            .where("departure_time", ">=", date_timestamp - timedelta(days=1))
-            .where("departure_time", "<=", date_timestamp + timedelta(days=1))
+            .where("departure_time", ">=", date_timestamp)
+            .where("departure_time", "<", date_timestamp + timedelta(days=1))
         )
 
         if departure_airport is None:

--- a/retrieval_service/datastore/providers/postgres.py
+++ b/retrieval_service/datastore/providers/postgres.py
@@ -368,7 +368,7 @@ class Client(datastore.Client[Config]):
                 SELECT * FROM flights
                 WHERE ($1::TEXT IS NULL OR departure_airport ILIKE $1)
                 AND ($2::TEXT IS NULL OR arrival_airport ILIKE $2)
-                AND departure_time > $3::timestamp - interval '1 day'
+                AND departure_time >= $3::timestamp
                 AND departure_time < $3::timestamp + interval '1 day';
             """,
             departure_airport,


### PR DESCRIPTION
when convert date into timestamp in postgresql, it will assign a default time of 00:00:00. Hence, our search return includes flights that are on the previous day.

fix by fixing the departure_time filtering sql statement.