### PR TITLE
fix(langchain_tools_demo): use relative paths for resources

### DIFF
--- a/langchain_tools_demo/static/index.js
+++ b/langchain_tools_demo/static/index.js
@@ -51,7 +51,7 @@ async function submitMessage() {
 
 // Send request to backend
 async function askQuestion(prompt) {
-    const response = await fetch('/chat', {
+    const response = await fetch('chat', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json'
@@ -68,7 +68,7 @@ async function askQuestion(prompt) {
 }
 
 async function reset() {
-    await fetch('/reset', {
+    await fetch('reset', {
         method: 'POST',
     }).then(()=>{
         window.location.reload()

--- a/langchain_tools_demo/templates/index.html
+++ b/langchain_tools_demo/templates/index.html
@@ -28,7 +28,7 @@ limitations under the License.
     <link href="https://fonts.googleapis.com/icon?family=Material+Symbols+Outlined" rel="stylesheet">
     <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
     <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
-    <link rel="stylesheet" href="/static/index.css">
+    <link rel="stylesheet" href="static/index.css">
     <script src="https://accounts.google.com/gsi/client" async defer></script>
 </head>
 
@@ -80,7 +80,7 @@ limitations under the License.
   src="https://code.jquery.com/jquery-3.7.1.slim.min.js"
   integrity="sha256-kmHvs0B+OpCW5GVHUNjv9rOmY0IvSIRcf7zGUDTDQM8="
   crossorigin="anonymous"></script>
-<script src="/static/index.js"></script>
+<script src="static/index.js"></script>
 <script>
   document.getElementById('g_id_onload').setAttribute('data-client_id', '{{ client_id }}');
   var currentUrl = window.location.href; 


### PR DESCRIPTION
Adjusts the LangChain Tools Demo to use relative paths so that it still works for TLs that run overly complicated IDE setups that need a proxy to access everything. 