### PR TITLE
chore: fix the refresh icon hiding behind Google banner

### DIFF
--- a/llm_demo/static/index.css
+++ b/llm_demo/static/index.css
@@ -51,8 +51,8 @@ body {
 #g_id_onload,
 .g_id_signin {
     position: absolute;
-    top: 20px;
-    right: 30px;
+    top: 8px;
+    right: 10px;
 }
 
 #menuButton {
@@ -61,7 +61,10 @@ body {
 }
 
 #resetButton {
-    float: right;
+    position: fixed;
+    top: 65px;
+    right: 15px;
+    color: #181a23;
     cursor: pointer;
 }
 
@@ -183,4 +186,9 @@ div.chat-wrapper div.chat-content div .sender-icon img {
 
 .mdl-progress.mdl-progress__indeterminate>.bar1 {
     background-color: #394867
+}
+
+.send-button {
+    margin-top: 12px;
+    margin-right: 12px;
 }

--- a/llm_demo/templates/index.html
+++ b/llm_demo/templates/index.html
@@ -67,7 +67,7 @@ limitations under the License.
                 <div class="mdl-progress mdl-js-progress mdl-progress__indeterminate"></div>
                 <div class="chat-input-container">
                     <input type="text" class="ip-msg" placeholder="type here...">
-                    <span class="btn-group">
+                    <span class="btn-group send-button">
                         <span class="material-symbols-outlined">
                             send
                         </span>


### PR DESCRIPTION
Move the reset button to not be behind
the Google Login Banner

<img width="795" alt="Screenshot 2024-02-27 at 1 55 51 PM" src="https://github.com/GoogleCloudPlatform/genai-databases-retrieval-app/assets/42976936/8a46062c-185e-4c80-b612-e8870269f966">


