### PR TITLE
Select stable model https://ai.google.dev/gemini-api/docs/models/gemi…

### DIFF
--- a/llm_demo/orchestrator/langchain_tools/langchain_tools_orchestrator.py
+++ b/llm_demo/orchestrator/langchain_tools/langchain_tools_orchestrator.py
@@ -333,7 +333,7 @@ class LangChainToolsOrchestrator(BaseOrchestrator):
         return prompt
 
     def get_datetime(self):
-        formatter = "%A, %Y-%m-%d, %H:%M:%S"
+        formatter = "%Y-%m-%d"
         now = datetime.now(timezone("US/Pacific"))
         return now.strftime(formatter)
 

--- a/llm_demo/orchestrator/orchestrator.py
+++ b/llm_demo/orchestrator/orchestrator.py
@@ -26,7 +26,7 @@ class classproperty:
 
 
 class BaseOrchestrator(ABC):
-    MODEL = "gemini-pro"
+    MODEL = "gemini-1.0-pro-001"
 
     @classproperty
     @abstractmethod


### PR DESCRIPTION
Revert to a stable version of gemini and remove time for predictive outcomes.