### PR TITLE
docs: add vpc peering instructions to alloydb instructions

### DIFF
--- a/docs/datastore/postgres.md
+++ b/docs/datastore/postgres.md
@@ -83,10 +83,10 @@ connect to your VPC. You should only need to do this once per VPC (per project).
    `$DB_PASS` and note it for future use:
 
     ```bash
-    export CLUSTER=my-alloydb-cluster
-    export DB_PASS=my-alloydb-pass
-    export INSTANCE=my-alloydb-instance
+    export CLUSTER=my-postgres-cluster
+    export INSTANCE=my-postgres-instance
     export REGION=us-central1
+    export DB_PASS=my-postgres-pass
     ```
 
 1. Create an AlloyDB cluster:
@@ -138,7 +138,7 @@ Private IP.
     ```bash
     export ZONE=us-central1-a
     export PROJECT_NUM=$(gcloud projects describe $PROJECT_ID --format="value(projectNumber)")
-    export VM_INSTANCE=alloydb-proxy-vm
+    export VM_INSTANCE=postgres-proxy-vm
     ```
 
 1. Create a Compute Engine VM:
@@ -196,7 +196,7 @@ datastore:
     # Update with database user, the default is `postgres`
     user: "postgres"
     # Update with database user password
-    password: "my-alloydb-pass"
+    password: "my-postgres-pass"
 ```
 
 ## Initialize data in AlloyDB
@@ -253,8 +253,8 @@ Clean up after completing the demo.
 1. Set environment variables:
 
     ```bash
-    export VM_INSTANCE=alloydb-proxy-vm
-    export CLUSTER=my-alloydb-cluster
+    export VM_INSTANCE=postgres-proxy-vm
+    export CLUSTER=my-postgres-cluster
     export REGION=us-central1
     export RANGE_NAME=my-allocated-range-default
     ```

--- a/retrieval_service/alloydb.tests.cloudbuild.yaml
+++ b/retrieval_service/alloydb.tests.cloudbuild.yaml
@@ -56,8 +56,8 @@ substitutions:
   _DATABASE_NAME: test_${SHORT_SHA}
   _DATABASE_USER: postgres
   _ALLOYDB_REGION: "us-central1"
-  _ALLOYDB_CLUSTER: "my-public-alloydb-cluster"
-  _ALLOYDB_INSTANCE: "my-public-alloydb-instance"
+  _ALLOYDB_CLUSTER: "my-alloydb-cluster"
+  _ALLOYDB_INSTANCE: "my-alloydb-instance"
 
 availableSecrets:
   secretManager:

--- a/retrieval_service/spanner.tests.cloudbuild.yaml
+++ b/retrieval_service/spanner.tests.cloudbuild.yaml
@@ -36,9 +36,6 @@ steps:
       - "DB_PROJECT=$PROJECT_ID"
       - "DB_INSTANCE=${_SPANNER_INSTANCE}"
       - "DB_NAME=${_DATABASE_NAME}"
-    secretEnv:
-      - DB_USER
-      - DB_PASS
     script: |
         #!/usr/bin/env bash
         python -m pytest datastore/providers/spanner_gsql_test.py


### PR DESCRIPTION
AlloyDB public IP database need to be created by creating a private alloydb instance first. Added VPC-peerings steps.

And a quick fix on spanner ci/cd (removing unnecessary secret env). 