### PR TITLE
chore: get prediction for eval dataset

### DIFF
--- a/llm_demo/evaluation/__init__.py
+++ b/llm_demo/evaluation/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .evaluation import Evaluation
+from .eval_golden import goldens
+from .evaluation import run_llm_for_eval
 
-__ALL__ = ["Evaluation"]
+__ALL__ = ["run_llm_for_eval", "goldens"]

--- a/llm_demo/evaluation/__init__.py
+++ b/llm_demo/evaluation/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .evaluation import Evaluation
+
+__ALL__ = ["Evaluation"]

--- a/llm_demo/evaluation/eval_golden.py
+++ b/llm_demo/evaluation/eval_golden.py
@@ -32,7 +32,7 @@ class EvalData(BaseModel):
     )
     content: Optional[str] = Field(default=None)
     tool_calls: Optional[List[ToolCall]] = Field(default=None)
-    context: Optional[str] = Field(
+    context: Optional[List[Any]] = Field(
         default=None, description="context given to llm in order to answer user query"
     )
     output: Optional[str] = Field(default=None)

--- a/llm_demo/evaluation/eval_golden.py
+++ b/llm_demo/evaluation/eval_golden.py
@@ -32,7 +32,7 @@ class EvalData(BaseModel):
     )
     content: Optional[str] = Field(default=None)
     tool_calls: Optional[List[ToolCall]] = Field(default=None)
-    context: Optional[List[Any]] = Field(
+    context: Optional[List[Dict[str, Any] | List[Dict[str, Any]]]] = Field(
         default=None, description="context given to llm in order to answer user query"
     )
     output: Optional[str] = Field(default=None)

--- a/llm_demo/evaluation/evaluation.py
+++ b/llm_demo/evaluation/evaluation.py
@@ -1,0 +1,84 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+from orchestrator import BaseOrchestrator
+
+from .eval_golden import goldens
+
+
+class EvalData(BaseModel):
+    category: Optional[str] = Field(default=None, description="evaluation category")
+    query: Optional[str] = Field(default=None, description="user query")
+    instruction: Optional[str] = Field(
+        default=None, description="instruction to llm system"
+    )
+    content: Optional[str] = Field(default=None)
+    tool_calls: Optional[List[Dict[str, Any]]] = Field(default=None)
+    context: Optional[str] = Field(
+        default=None, description="context given to llm in order to answer user query"
+    )
+    output: Optional[str] = Field(default=None)
+    prediction_tool_calls: Optional[List[Dict[str, Any]]] = Field(default=None)
+    prediction_output: Optional[str] = Field(default=None)
+    reset: bool = Field(
+        default=True, description="determine to reset the chat after invoke"
+    )
+
+
+class Evaluation:
+    def load_golden_data(self) -> List[EvalData]:
+        """
+        Load golden dataset into EvalData model.
+        """
+        eval_datas = []
+        for golden in goldens:
+            for key in golden:
+                cases = golden[key]
+                for case in cases:
+                    data = EvalData(**case)
+                    data.category = key
+                    eval_datas.append(data)
+        return eval_datas
+
+    async def run_llm_for_eval(
+        self, eval_datas: List[EvalData], orc: BaseOrchestrator, session: Dict, uid: str
+    ) -> List[EvalData]:
+        """
+        Generate prediction_tool_calls and prediction_output for golden dataset query.
+        """
+        agent = orc.get_user_session(uid)
+        for eval_data in eval_datas:
+            query_response = await agent.invoke(eval_data.query)
+
+            # Retrieve prediction_tool_calls from query response
+            prediction_tool_calls = []
+            for step in query_response.get("intermediate_steps"):
+                called_tool = step[0]
+                tool_call = {
+                    "name": called_tool.tool,
+                    "arguments": called_tool.tool_input,
+                }
+                prediction_tool_calls.append(tool_call)
+
+            eval_data.prediction_tool_calls = prediction_tool_calls
+            eval_data.prediction_output = query_response.get("output")
+
+            if eval_data.reset:
+                orc.user_session_reset(session, uid)
+        return eval_datas

--- a/llm_demo/evaluation/evaluation.py
+++ b/llm_demo/evaluation/evaluation.py
@@ -12,57 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
-from typing import Any, Dict, List, Optional
-
-from pydantic import BaseModel, Field
+from typing import Dict, List
 
 from orchestrator import BaseOrchestrator
 
-from .eval_golden import goldens
+from .eval_golden import EvalData
 
-
-class EvalData(BaseModel):
-    category: Optional[str] = Field(default=None, description="evaluation category")
-    query: Optional[str] = Field(default=None, description="user query")
-    instruction: Optional[str] = Field(
-        default=None, description="instruction to llm system"
-    )
-    content: Optional[str] = Field(default=None)
-    tool_calls: Optional[List[Dict[str, Any]]] = Field(default=None)
-    context: Optional[str] = Field(
-        default=None, description="context given to llm in order to answer user query"
-    )
-    output: Optional[str] = Field(default=None)
-    prediction_tool_calls: Optional[List[Dict[str, Any]]] = Field(default=None)
-    prediction_output: Optional[str] = Field(default=None)
-    reset: bool = Field(
-        default=True, description="determine to reset the chat after invoke"
-    )
-
-
-def load_golden_data() -> List[EvalData]:
-    """
-    Load golden dataset into EvalData model.
-    """
-    eval_datas = []
-    for golden in goldens:
-        for key in golden:
-            cases = golden[key]
-            for case in cases:
-                data = EvalData(**case)
-                data.category = key
-                eval_datas.append(data)
-    return eval_datas
 
 async def run_llm_for_eval(
-    eval_list: List[EvalData], orc: BaseOrchestrator, session: Dict, uid: str
+    eval_list: List[EvalData], orc: BaseOrchestrator, session: Dict, session_id: str
 ) -> List[EvalData]:
     """
     Generate prediction_tool_calls and prediction_output for golden dataset query.
     """
-    agent = orc.get_user_session(uid)
-    for eval_data in eval_datas:
+    agent = orc.get_user_session(session_id)
+    for eval_data in eval_list:
         query_response = await agent.invoke(eval_data.query)
 
         # Retrieve prediction_tool_calls from query response
@@ -79,5 +43,5 @@ async def run_llm_for_eval(
         eval_data.prediction_output = query_response.get("output")
 
         if eval_data.reset:
-            orc.user_session_reset(session, uid)
-    return eval_datas
+            orc.user_session_reset(session, session_id)
+    return eval_list

--- a/llm_demo/evaluation/evaluation.py
+++ b/llm_demo/evaluation/evaluation.py
@@ -41,44 +41,43 @@ class EvalData(BaseModel):
     )
 
 
-class Evaluation:
-    def load_golden_data(self) -> List[EvalData]:
-        """
-        Load golden dataset into EvalData model.
-        """
-        eval_datas = []
-        for golden in goldens:
-            for key in golden:
-                cases = golden[key]
-                for case in cases:
-                    data = EvalData(**case)
-                    data.category = key
-                    eval_datas.append(data)
-        return eval_datas
+def load_golden_data() -> List[EvalData]:
+    """
+    Load golden dataset into EvalData model.
+    """
+    eval_datas = []
+    for golden in goldens:
+        for key in golden:
+            cases = golden[key]
+            for case in cases:
+                data = EvalData(**case)
+                data.category = key
+                eval_datas.append(data)
+    return eval_datas
 
-    async def run_llm_for_eval(
-        self, eval_datas: List[EvalData], orc: BaseOrchestrator, session: Dict, uid: str
-    ) -> List[EvalData]:
-        """
-        Generate prediction_tool_calls and prediction_output for golden dataset query.
-        """
-        agent = orc.get_user_session(uid)
-        for eval_data in eval_datas:
-            query_response = await agent.invoke(eval_data.query)
+async def run_llm_for_eval(
+    eval_list: List[EvalData], orc: BaseOrchestrator, session: Dict, uid: str
+) -> List[EvalData]:
+    """
+    Generate prediction_tool_calls and prediction_output for golden dataset query.
+    """
+    agent = orc.get_user_session(uid)
+    for eval_data in eval_datas:
+        query_response = await agent.invoke(eval_data.query)
 
-            # Retrieve prediction_tool_calls from query response
-            prediction_tool_calls = []
-            for step in query_response.get("intermediate_steps"):
-                called_tool = step[0]
-                tool_call = {
-                    "name": called_tool.tool,
-                    "arguments": called_tool.tool_input,
-                }
-                prediction_tool_calls.append(tool_call)
+        # Retrieve prediction_tool_calls from query response
+        prediction_tool_calls = []
+        for step in query_response.get("intermediate_steps"):
+            called_tool = step[0]
+            tool_call = {
+                "name": called_tool.tool,
+                "arguments": called_tool.tool_input,
+            }
+            prediction_tool_calls.append(tool_call)
 
-            eval_data.prediction_tool_calls = prediction_tool_calls
-            eval_data.prediction_output = query_response.get("output")
+        eval_data.prediction_tool_calls = prediction_tool_calls
+        eval_data.prediction_output = query_response.get("output")
 
-            if eval_data.reset:
-                orc.user_session_reset(session, uid)
-        return eval_datas
+        if eval_data.reset:
+            orc.user_session_reset(session, uid)
+    return eval_datas


### PR DESCRIPTION
Add the function to get prediction for each of the queries from golden_dataset. Prediction is used as comparison to retrieve metrics.

Usage example:

```
from evaluation import run_llm_for_eval, goldens

# set up orchestration, session, set uuid
eval_list = await run_llm_for_eval(goldens, orchestration, session, session_id)
```