### PR TITLE
fix loginUri for llm_demo when original URL has query params

### DIFF
--- a/llm_demo/templates/index.html
+++ b/llm_demo/templates/index.html
@@ -114,7 +114,7 @@ limitations under the License.
 <script>
   document.getElementById('g_id_onload').setAttribute('data-client_id', '{{ client_id }}');
   var currentUrl = window.location.href;
-  var loginUri = currentUrl + 'login/google';
+  var loginUri = currentUrl.split('?')[0] + 'login/google';
   document.getElementById('g_id_onload').setAttribute('data-login_uri', loginUri);
 </script>
 


### PR DESCRIPTION
loginUri was adding 'login/google' to the URL, including query params.

This change strips query parameters before concatenating 'login/google'.