### PR TITLE
chore: add sql return to retrieval service

### DIFF
--- a/retrieval_service/app/app_test.py
+++ b/retrieval_service/app/app_test.py
@@ -94,14 +94,17 @@ get_airport_params = [
 def test_get_airport(m_datastore, app, method_name, params, mock_return, expected):
     with TestClient(app) as client:
         with patch.object(
-            m_datastore.return_value, method_name, AsyncMock(return_value=mock_return)
+            m_datastore.return_value,
+            method_name,
+            AsyncMock(return_value=(mock_return, None)),
         ) as mock_method:
             response = client.get(
                 "/airports",
                 params=params,
             )
     assert response.status_code == 200
-    output = response.json()
+    res = response.json()
+    output = res["results"]
     assert output == expected
     assert models.Airport.model_validate(output)
 
@@ -213,14 +216,17 @@ search_airports_params = [
 def test_search_airports(m_datastore, app, method_name, params, mock_return, expected):
     with TestClient(app) as client:
         with patch.object(
-            m_datastore.return_value, method_name, AsyncMock(return_value=mock_return)
+            m_datastore.return_value,
+            method_name,
+            AsyncMock(return_value=(mock_return, None)),
         ) as mock_method:
             response = client.get(
                 "/airports/search",
                 params=params,
             )
     assert response.status_code == 200
-    output = response.json()
+    res = response.json()
+    output = res["results"]
     assert output == expected
     assert models.Airport.model_validate(output[0])
 
@@ -288,7 +294,9 @@ get_amenity_params = [
 def test_get_amenity(m_datastore, app, method_name, params, mock_return, expected):
     with TestClient(app) as client:
         with patch.object(
-            m_datastore.return_value, method_name, AsyncMock(return_value=mock_return)
+            m_datastore.return_value,
+            method_name,
+            AsyncMock(return_value=(mock_return, None)),
         ) as mock_method:
             response = client.get(
                 "/amenities",
@@ -297,7 +305,8 @@ def test_get_amenity(m_datastore, app, method_name, params, mock_return, expecte
                 },
             )
     assert response.status_code == 200
-    output = response.json()
+    res = response.json()
+    output = res["results"]
     assert output == expected
     assert models.Amenity.model_validate(output)
 
@@ -392,14 +401,17 @@ amenities_search_params = [
 def test_amenities_search(m_datastore, app, method_name, params, mock_return, expected):
     with TestClient(app) as client:
         with patch.object(
-            m_datastore.return_value, method_name, AsyncMock(return_value=mock_return)
+            m_datastore.return_value,
+            method_name,
+            AsyncMock(return_value=(mock_return, None)),
         ) as mock_method:
             response = client.get(
                 "/amenities/search",
                 params=params,
             )
     assert response.status_code == 200
-    output = response.json()
+    res = response.json()
+    output = res["results"]
     assert len(output) == params["top_k"]
     assert output == expected
     assert models.Amenity.model_validate(output[0])
@@ -445,14 +457,17 @@ get_flight_params = [
 def test_get_flight(m_datastore, app, method_name, params, mock_return, expected):
     with TestClient(app) as client:
         with patch.object(
-            m_datastore.return_value, method_name, AsyncMock(return_value=mock_return)
+            m_datastore.return_value,
+            method_name,
+            AsyncMock(return_value=(mock_return, None)),
         ) as mock_method:
             response = client.get(
                 "/flights",
                 params=params,
             )
     assert response.status_code == 200
-    output = response.json()
+    res = response.json()
+    output = res["results"]
     assert output == expected
     assert models.Flight.model_validate(output)
 
@@ -612,11 +627,14 @@ search_flights_params = [
 def test_search_flights(m_datastore, app, method_name, params, mock_return, expected):
     with TestClient(app) as client:
         with patch.object(
-            m_datastore.return_value, method_name, AsyncMock(return_value=mock_return)
+            m_datastore.return_value,
+            method_name,
+            AsyncMock(return_value=(mock_return, None)),
         ) as mock_method:
             response = client.get("/flights/search", params=params)
     assert response.status_code == 200
-    output = response.json()
+    res = response.json()
+    output = res["results"]
     assert output == expected
     assert models.Flight.model_validate(output[0])
 
@@ -708,11 +726,14 @@ validate_ticket_params = [
 def test_validate_ticket(m_datastore, app, method_name, params, mock_return, expected):
     with TestClient(app) as client:
         with patch.object(
-            m_datastore.return_value, method_name, AsyncMock(return_value=mock_return)
+            m_datastore.return_value,
+            method_name,
+            AsyncMock(return_value=(mock_return, None)),
         ) as mock_method:
             response = client.get("/tickets/validate", params=params)
     assert response.status_code == 200
-    output = response.json()
+    res = response.json()
+    output = res["results"]
     assert output == expected
     assert models.Flight.model_validate(output[0])
 
@@ -748,14 +769,17 @@ policies_search_params = [
 def test_policies_search(m_datastore, app, method_name, params, mock_return, expected):
     with TestClient(app) as client:
         with patch.object(
-            m_datastore.return_value, method_name, AsyncMock(return_value=mock_return)
+            m_datastore.return_value,
+            method_name,
+            AsyncMock(return_value=(mock_return, None)),
         ) as mock_method:
             response = client.get(
                 "/policies/search",
                 params=params,
             )
     assert response.status_code == 200
-    output = response.json()
+    res = response.json()
+    output = res["results"]
     assert len(output) == params["top_k"]
     assert output == expected
     assert models.Policy.model_validate(output[0])

--- a/retrieval_service/app/routes.py
+++ b/retrieval_service/app/routes.py
@@ -77,7 +77,7 @@ async def get_airport(
             status_code=422,
             detail="Request requires query params: airport id or iata",
         )
-    return {"results": results, "sql": sql, "error": None}
+    return {"results": results, "sql": sql}
 
 
 @routes.get("/airports/search")
@@ -95,14 +95,14 @@ async def search_airports(
 
     ds: datastore.Client = request.app.state.datastore
     results, sql = await ds.search_airports(country, city, name)
-    return {"results": results, "sql": sql, "error": None}
+    return {"results": results, "sql": sql}
 
 
 @routes.get("/amenities")
 async def get_amenity(id: int, request: Request):
     ds: datastore.Client = request.app.state.datastore
     results, sql = await ds.get_amenity(id)
-    return {"results": results, "sql": sql, "error": None}
+    return {"results": results, "sql": sql}
 
 
 @routes.get("/amenities/search")
@@ -113,14 +113,14 @@ async def amenities_search(query: str, top_k: int, request: Request):
     query_embedding = embed_service.embed_query(query)
 
     results, sql = await ds.amenities_search(query_embedding, 0.5, top_k)
-    return {"results": results, "sql": sql, "error": None}
+    return {"results": results, "sql": sql}
 
 
 @routes.get("/flights")
 async def get_flight(flight_id: int, request: Request):
     ds: datastore.Client = request.app.state.datastore
     results, sql = await ds.get_flight(flight_id)
-    return {"results": results, "sql": sql, "error": None}
+    return {"results": results, "sql": sql}
 
 
 @routes.get("/flights/search")
@@ -144,7 +144,7 @@ async def search_flights(
             status_code=422,
             detail="Request requires query params: arrival_airport, departure_airport, date, or both airline and flight_number",
         )
-    return {"results": results, "sql": sql, "error": None}
+    return {"results": results, "sql": sql}
 
 
 @routes.post("/tickets/insert")
@@ -193,7 +193,7 @@ async def validate_ticket(
         departure_airport,
         departure_time,
     )
-    return {"results": results, "sql": sql, "error": None}
+    return {"results": results, "sql": sql}
 
 
 @routes.get("/tickets/list")
@@ -208,7 +208,7 @@ async def list_tickets(
         )
     ds: datastore.Client = request.app.state.datastore
     results, sql = await ds.list_tickets(user_info["user_id"])
-    return {"results": results, "sql": sql, "error": None}
+    return {"results": results, "sql": sql}
 
 
 @routes.get("/policies/search")
@@ -219,4 +219,4 @@ async def policies_search(query: str, top_k: int, request: Request):
     query_embedding = embed_service.embed_query(query)
 
     results, sql = await ds.policies_search(query_embedding, 0.5, top_k)
-    return {"results": results, "sql": sql, "error": None}
+    return {"results": results, "sql": sql}

--- a/retrieval_service/app/routes.py
+++ b/retrieval_service/app/routes.py
@@ -69,15 +69,15 @@ async def get_airport(
 ):
     ds: datastore.Client = request.app.state.datastore
     if id:
-        results = await ds.get_airport_by_id(id)
+        results, sql = await ds.get_airport_by_id(id)
     elif iata:
-        results = await ds.get_airport_by_iata(iata)
+        results, sql = await ds.get_airport_by_iata(iata)
     else:
         raise HTTPException(
             status_code=422,
             detail="Request requires query params: airport id or iata",
         )
-    return results
+    return {"results": results, "sql": sql}
 
 
 @routes.get("/airports/search")
@@ -94,15 +94,15 @@ async def search_airports(
         )
 
     ds: datastore.Client = request.app.state.datastore
-    results = await ds.search_airports(country, city, name)
-    return results
+    results, sql = await ds.search_airports(country, city, name)
+    return {"results": results, "sql": sql}
 
 
 @routes.get("/amenities")
 async def get_amenity(id: int, request: Request):
     ds: datastore.Client = request.app.state.datastore
-    results = await ds.get_amenity(id)
-    return results
+    results, sql = await ds.get_amenity(id)
+    return {"results": results, "sql": sql}
 
 
 @routes.get("/amenities/search")
@@ -112,15 +112,15 @@ async def amenities_search(query: str, top_k: int, request: Request):
     embed_service: Embeddings = request.app.state.embed_service
     query_embedding = embed_service.embed_query(query)
 
-    results = await ds.amenities_search(query_embedding, 0.5, top_k)
-    return results
+    results, sql = await ds.amenities_search(query_embedding, 0.5, top_k)
+    return {"results": results, "sql": sql}
 
 
 @routes.get("/flights")
 async def get_flight(flight_id: int, request: Request):
     ds: datastore.Client = request.app.state.datastore
-    flights = await ds.get_flight(flight_id)
-    return flights
+    results, sql = await ds.get_flight(flight_id)
+    return {"results": results, "sql": sql}
 
 
 @routes.get("/flights/search")
@@ -134,17 +134,17 @@ async def search_flights(
 ):
     ds: datastore.Client = request.app.state.datastore
     if date and (arrival_airport or departure_airport):
-        flights = await ds.search_flights_by_airports(
+        results, sql = await ds.search_flights_by_airports(
             date, departure_airport, arrival_airport
         )
     elif airline and flight_number:
-        flights = await ds.search_flights_by_number(airline, flight_number)
+        results, sql = await ds.search_flights_by_number(airline, flight_number)
     else:
         raise HTTPException(
             status_code=422,
             detail="Request requires query params: arrival_airport, departure_airport, date, or both airline and flight_number",
         )
-    return flights
+    return {"results": results, "sql": sql}
 
 
 @routes.post("/tickets/insert")
@@ -164,7 +164,7 @@ async def insert_ticket(
             detail="User login required for data insertion",
         )
     ds: datastore.Client = request.app.state.datastore
-    result = await ds.insert_ticket(
+    results, sql = await ds.insert_ticket(
         user_info["user_id"],
         user_info["user_name"],
         user_info["user_email"],
@@ -175,7 +175,7 @@ async def insert_ticket(
         departure_time,
         arrival_time,
     )
-    return result
+    return {"results": results, "sql": sql}
 
 
 @routes.get("/tickets/validate")
@@ -187,13 +187,13 @@ async def validate_ticket(
     departure_time: str,
 ):
     ds: datastore.Client = request.app.state.datastore
-    result = await ds.validate_ticket(
+    results, sql = await ds.validate_ticket(
         airline,
         flight_number,
         departure_airport,
         departure_time,
     )
-    return result
+    return {"results": results, "sql": sql}
 
 
 @routes.get("/tickets/list")
@@ -207,8 +207,8 @@ async def list_tickets(
             detail="User login required for data insertion",
         )
     ds: datastore.Client = request.app.state.datastore
-    results = await ds.list_tickets(user_info["user_id"])
-    return results
+    results, sql = await ds.list_tickets(user_info["user_id"])
+    return {"results": results, "sql": sql}
 
 
 @routes.get("/policies/search")
@@ -218,5 +218,5 @@ async def policies_search(query: str, top_k: int, request: Request):
     embed_service: Embeddings = request.app.state.embed_service
     query_embedding = embed_service.embed_query(query)
 
-    results = await ds.policies_search(query_embedding, 0.5, top_k)
-    return results
+    results, sql = await ds.policies_search(query_embedding, 0.5, top_k)
+    return {"results": results, "sql": sql}

--- a/retrieval_service/app/routes.py
+++ b/retrieval_service/app/routes.py
@@ -77,7 +77,7 @@ async def get_airport(
             status_code=422,
             detail="Request requires query params: airport id or iata",
         )
-    return {"results": results, "sql": sql}
+    return {"results": results, "sql": sql, "error": None}
 
 
 @routes.get("/airports/search")
@@ -95,14 +95,14 @@ async def search_airports(
 
     ds: datastore.Client = request.app.state.datastore
     results, sql = await ds.search_airports(country, city, name)
-    return {"results": results, "sql": sql}
+    return {"results": results, "sql": sql, "error": None}
 
 
 @routes.get("/amenities")
 async def get_amenity(id: int, request: Request):
     ds: datastore.Client = request.app.state.datastore
     results, sql = await ds.get_amenity(id)
-    return {"results": results, "sql": sql}
+    return {"results": results, "sql": sql, "error": None}
 
 
 @routes.get("/amenities/search")
@@ -113,14 +113,14 @@ async def amenities_search(query: str, top_k: int, request: Request):
     query_embedding = embed_service.embed_query(query)
 
     results, sql = await ds.amenities_search(query_embedding, 0.5, top_k)
-    return {"results": results, "sql": sql}
+    return {"results": results, "sql": sql, "error": None}
 
 
 @routes.get("/flights")
 async def get_flight(flight_id: int, request: Request):
     ds: datastore.Client = request.app.state.datastore
     results, sql = await ds.get_flight(flight_id)
-    return {"results": results, "sql": sql}
+    return {"results": results, "sql": sql, "error": None}
 
 
 @routes.get("/flights/search")
@@ -144,7 +144,7 @@ async def search_flights(
             status_code=422,
             detail="Request requires query params: arrival_airport, departure_airport, date, or both airline and flight_number",
         )
-    return {"results": results, "sql": sql}
+    return {"results": results, "sql": sql, "error": None}
 
 
 @routes.post("/tickets/insert")
@@ -164,7 +164,7 @@ async def insert_ticket(
             detail="User login required for data insertion",
         )
     ds: datastore.Client = request.app.state.datastore
-    results, sql = await ds.insert_ticket(
+    results = await ds.insert_ticket(
         user_info["user_id"],
         user_info["user_name"],
         user_info["user_email"],
@@ -175,7 +175,7 @@ async def insert_ticket(
         departure_time,
         arrival_time,
     )
-    return {"results": results, "sql": sql}
+    return results
 
 
 @routes.get("/tickets/validate")
@@ -193,7 +193,7 @@ async def validate_ticket(
         departure_airport,
         departure_time,
     )
-    return {"results": results, "sql": sql}
+    return {"results": results, "sql": sql, "error": None}
 
 
 @routes.get("/tickets/list")
@@ -208,7 +208,7 @@ async def list_tickets(
         )
     ds: datastore.Client = request.app.state.datastore
     results, sql = await ds.list_tickets(user_info["user_id"])
-    return {"results": results, "sql": sql}
+    return {"results": results, "sql": sql, "error": None}
 
 
 @routes.get("/policies/search")
@@ -219,4 +219,4 @@ async def policies_search(query: str, top_k: int, request: Request):
     query_embedding = embed_service.embed_query(query)
 
     results, sql = await ds.policies_search(query_embedding, 0.5, top_k)
-    return {"results": results, "sql": sql}
+    return {"results": results, "sql": sql, "error": None}

--- a/retrieval_service/datastore/datastore.py
+++ b/retrieval_service/datastore/datastore.py
@@ -173,11 +173,15 @@ class Client(ABC, Generic[C]):
         pass
 
     @abstractmethod
-    async def get_airport_by_id(self, id: int) -> Optional[models.Airport]:
+    async def get_airport_by_id(
+        self, id: int
+    ) -> tuple[Optional[models.Airport], Optional[str]]:
         raise NotImplementedError("Subclass should implement this!")
 
     @abstractmethod
-    async def get_airport_by_iata(self, iata: str) -> Optional[models.Airport]:
+    async def get_airport_by_iata(
+        self, iata: str
+    ) -> tuple[Optional[models.Airport], Optional[str]]:
         raise NotImplementedError("Subclass should implement this!")
 
     @abstractmethod
@@ -186,21 +190,25 @@ class Client(ABC, Generic[C]):
         country: Optional[str] = None,
         city: Optional[str] = None,
         name: Optional[str] = None,
-    ) -> list[models.Airport]:
+    ) -> tuple[list[models.Airport], Optional[str]]:
         raise NotImplementedError("Subclass should implement this!")
 
     @abstractmethod
-    async def get_amenity(self, id: int) -> Optional[models.Amenity]:
+    async def get_amenity(
+        self, id: int
+    ) -> tuple[Optional[models.Amenity], Optional[str]]:
         raise NotImplementedError("Subclass should implement this!")
 
     @abstractmethod
     async def amenities_search(
         self, query_embedding: list[float], similarity_threshold: float, top_k: int
-    ) -> list[Any]:
+    ) -> tuple[list[Any], Optional[str]]:
         raise NotImplementedError("Subclass should implement this!")
 
     @abstractmethod
-    async def get_flight(self, flight_id: int) -> Optional[models.Flight]:
+    async def get_flight(
+        self, flight_id: int
+    ) -> tuple[Optional[models.Flight], Optional[str]]:
         raise NotImplementedError("Subclass should implement this!")
 
     @abstractmethod
@@ -208,7 +216,7 @@ class Client(ABC, Generic[C]):
         self,
         airline: str,
         flight_number: str,
-    ) -> list[models.Flight]:
+    ) -> tuple[list[models.Flight], Optional[str]]:
         raise NotImplementedError("Subclass should implement this!")
 
     @abstractmethod
@@ -217,7 +225,7 @@ class Client(ABC, Generic[C]):
         date,
         departure_airport: Optional[str] = None,
         arrival_airport: Optional[str] = None,
-    ) -> list[models.Flight]:
+    ) -> tuple[list[models.Flight], Optional[str]]:
         raise NotImplementedError("Subclass should implement this!")
 
     @abstractmethod
@@ -227,7 +235,7 @@ class Client(ABC, Generic[C]):
         flight_number: str,
         departure_airport: str,
         departure_time: str,
-    ) -> Optional[models.Flight]:
+    ) -> tuple[Optional[models.Flight], Optional[str]]:
         raise NotImplementedError("Subclass should implement this!")
 
     @abstractmethod
@@ -249,13 +257,13 @@ class Client(ABC, Generic[C]):
     async def list_tickets(
         self,
         user_id: str,
-    ) -> list[models.Ticket]:
+    ) -> tuple[list[models.Ticket], Optional[str]]:
         raise NotImplementedError("Subclass should implement this!")
 
     @abstractmethod
     async def policies_search(
         self, query_embedding: list[float], similarity_threshold: float, top_k: int
-    ) -> list[str]:
+    ) -> tuple[list[str], Optional[str]]:
         raise NotImplementedError("Subclass should implement this!")
 
     @abstractmethod

--- a/retrieval_service/datastore/providers/alloydb_test.py
+++ b/retrieval_service/datastore/providers/alloydb_test.py
@@ -202,7 +202,7 @@ async def test_export_dataset(ds: alloydb.Client):
 
 
 async def test_get_airport_by_id(ds: alloydb.Client):
-    res = await ds.get_airport_by_id(1)
+    res, sql = await ds.get_airport_by_id(1)
     expected = models.Airport(
         id=1,
         iata="MAG",
@@ -211,6 +211,7 @@ async def test_get_airport_by_id(ds: alloydb.Client):
         country="Papua New Guinea",
     )
     assert res == expected
+    assert sql is not None
 
 
 @pytest.mark.parametrize(
@@ -221,7 +222,7 @@ async def test_get_airport_by_id(ds: alloydb.Client):
     ],
 )
 async def test_get_airport_by_iata(ds: alloydb.Client, iata: str):
-    res = await ds.get_airport_by_iata(iata)
+    res, sql = await ds.get_airport_by_iata(iata)
     expected = models.Airport(
         id=3270,
         iata="SFO",
@@ -230,6 +231,7 @@ async def test_get_airport_by_iata(ds: alloydb.Client, iata: str):
         country="United States",
     )
     assert res == expected
+    assert sql is not None
 
 
 search_airports_test_data = [
@@ -310,12 +312,13 @@ async def test_search_airports(
     name: str,
     expected: List[models.Airport],
 ):
-    res = await ds.search_airports(country, city, name)
+    res, sql = await ds.search_airports(country, city, name)
     assert res == expected
+    assert sql is not None
 
 
 async def test_get_amenity(ds: alloydb.Client):
-    res = await ds.get_amenity(0)
+    res, sql = await ds.get_amenity(0)
     expected = models.Amenity(
         id=0,
         name="Coffee Shop 732",
@@ -340,6 +343,7 @@ async def test_get_amenity(ds: alloydb.Client):
         saturday_end_hour=None,
     )
     assert res == expected
+    assert sql is not None
 
 
 amenities_search_test_data = [
@@ -406,12 +410,13 @@ async def test_amenities_search(
     top_k: int,
     expected: List[Any],
 ):
-    res = await ds.amenities_search(query_embedding, similarity_threshold, top_k)
+    res, sql = await ds.amenities_search(query_embedding, similarity_threshold, top_k)
     assert res == expected
+    assert sql is not None
 
 
 async def test_get_flight(ds: alloydb.Client):
-    res = await ds.get_flight(1)
+    res, sql = await ds.get_flight(1)
     expected = models.Flight(
         id=1,
         airline="UA",
@@ -424,6 +429,7 @@ async def test_get_flight(ds: alloydb.Client):
         arrival_gate="D30",
     )
     assert res == expected
+    assert sql is not None
 
 
 search_flights_by_number_test_data = [
@@ -482,8 +488,9 @@ async def test_search_flights_by_number(
     number: str,
     expected: List[models.Flight],
 ):
-    res = await ds.search_flights_by_number(airline, number)
+    res, sql = await ds.search_flights_by_number(airline, number)
     assert res == expected
+    assert sql is not None
 
 
 search_flights_by_airports_test_data = [
@@ -606,8 +613,11 @@ async def test_search_flights_by_airports(
     arrival_airport: str,
     expected: List[models.Flight],
 ):
-    res = await ds.search_flights_by_airports(date, departure_airport, arrival_airport)
+    res, sql = await ds.search_flights_by_airports(
+        date, departure_airport, arrival_airport
+    )
     assert res == expected
+    assert sql is not None
 
 
 policies_search_test_data = [
@@ -653,5 +663,6 @@ async def test_policies_search(
     top_k: int,
     expected: List[str],
 ):
-    res = await ds.policies_search(query_embedding, similarity_threshold, top_k)
+    res, sql = await ds.policies_search(query_embedding, similarity_threshold, top_k)
     assert res == expected
+    assert sql is not None

--- a/retrieval_service/datastore/providers/cloudsql_mysql.py
+++ b/retrieval_service/datastore/providers/cloudsql_mysql.py
@@ -406,46 +406,54 @@ class Client(datastore.Client[Config]):
         res = await loop.run_in_executor(None, self.export_data_sync)
         return res
 
-    def get_airport_by_id_sync(self, id: int) -> Optional[models.Airport]:
+    def get_airport_by_id_sync(
+        self, id: int
+    ) -> tuple[Optional[models.Airport], Optional[str]]:
         with self.__pool.connect() as conn:
             s = text("""SELECT * FROM airports WHERE id=:id""")
             params = {"id": id}
             result = (conn.execute(s, params)).mappings().fetchone()
 
         if result is None:
-            return None
+            return None, None
 
         res = models.Airport.model_validate(result)
-        return res
+        return res, None
 
-    async def get_airport_by_id(self, id: int) -> Optional[models.Airport]:
+    async def get_airport_by_id(
+        self, id: int
+    ) -> tuple[Optional[models.Airport], Optional[str]]:
         loop = asyncio.get_running_loop()
-        res = await loop.run_in_executor(None, self.get_airport_by_id_sync, id)
-        return res
+        res, sql = await loop.run_in_executor(None, self.get_airport_by_id_sync, id)
+        return res, sql
 
-    def get_airport_by_iata_sync(self, iata: str) -> Optional[models.Airport]:
+    def get_airport_by_iata_sync(
+        self, iata: str
+    ) -> tuple[Optional[models.Airport], Optional[str]]:
         with self.__pool.connect() as conn:
             s = text("""SELECT * FROM airports WHERE LOWER(iata) LIKE LOWER(:iata)""")
             params = {"iata": iata}
             result = (conn.execute(s, params)).mappings().fetchone()
 
         if result is None:
-            return None
+            return None, None
 
         res = models.Airport.model_validate(result)
-        return res
+        return res, None
 
-    async def get_airport_by_iata(self, iata: str) -> Optional[models.Airport]:
+    async def get_airport_by_iata(
+        self, iata: str
+    ) -> tuple[Optional[models.Airport], Optional[str]]:
         loop = asyncio.get_running_loop()
-        res = await loop.run_in_executor(None, self.get_airport_by_iata_sync, iata)
-        return res
+        res, sql = await loop.run_in_executor(None, self.get_airport_by_iata_sync, iata)
+        return res, sql
 
     def search_airports_sync(
         self,
         country: Optional[str] = None,
         city: Optional[str] = None,
         name: Optional[str] = None,
-    ) -> list[models.Airport]:
+    ) -> tuple[list[models.Airport], Optional[str]]:
         with self.__pool.connect() as conn:
             s = text(
                 """
@@ -464,21 +472,23 @@ class Client(datastore.Client[Config]):
             results = (conn.execute(s, parameters=params)).mappings().fetchall()
 
         res = [models.Airport.model_validate(r) for r in results]
-        return res
+        return res, None
 
     async def search_airports(
         self,
         country: Optional[str] = None,
         city: Optional[str] = None,
         name: Optional[str] = None,
-    ) -> list[models.Airport]:
+    ) -> tuple[list[models.Airport], Optional[str]]:
         loop = asyncio.get_running_loop()
-        res = await loop.run_in_executor(
+        res, sql = await loop.run_in_executor(
             None, self.search_airports_sync, country, city, name
         )
-        return res
+        return res, sql
 
-    def get_amenity_sync(self, id: int) -> Optional[models.Amenity]:
+    def get_amenity_sync(
+        self, id: int
+    ) -> tuple[Optional[models.Amenity], Optional[str]]:
         with self.__pool.connect() as conn:
             s = text(
                 """
@@ -490,19 +500,21 @@ class Client(datastore.Client[Config]):
             result = (conn.execute(s, parameters=params)).mappings().fetchone()
 
         if result is None:
-            return None
+            return None, None
 
         res = models.Amenity.model_validate(result)
-        return res
+        return res, None
 
-    async def get_amenity(self, id: int) -> Optional[models.Amenity]:
+    async def get_amenity(
+        self, id: int
+    ) -> tuple[Optional[models.Amenity], Optional[str]]:
         loop = asyncio.get_running_loop()
-        res = await loop.run_in_executor(None, self.get_amenity_sync, id)
-        return res
+        res, sql = await loop.run_in_executor(None, self.get_amenity_sync, id)
+        return res, sql
 
     def amenities_search_sync(
         self, query_embedding: list[float], similarity_threshold: float, top_k: int
-    ) -> list[Any]:
+    ) -> tuple[list[Any], Optional[str]]:
         with self.__pool.connect() as conn:
             s = text(
                 """
@@ -518,22 +530,24 @@ class Client(datastore.Client[Config]):
             results = (conn.execute(s, parameters=params)).mappings().fetchall()
 
         res = [r for r in results]
-        return res
+        return res, None
 
     async def amenities_search(
         self, query_embedding: list[float], similarity_threshold: float, top_k: int
-    ) -> list[Any]:
+    ) -> tuple[list[Any], Optional[str]]:
         loop = asyncio.get_running_loop()
-        res = await loop.run_in_executor(
+        res, sql = await loop.run_in_executor(
             None,
             self.amenities_search_sync,
             query_embedding,
             similarity_threshold,
             top_k,
         )
-        return res
+        return res, sql
 
-    def get_flight_sync(self, flight_id: int) -> Optional[models.Flight]:
+    def get_flight_sync(
+        self, flight_id: int
+    ) -> tuple[Optional[models.Flight], Optional[str]]:
         with self.__pool.connect() as conn:
             s = text(
                 """
@@ -545,21 +559,23 @@ class Client(datastore.Client[Config]):
             result = (conn.execute(s, parameters=params)).mappings().fetchone()
 
         if result is None:
-            return None
+            return None, None
 
         res = models.Flight.model_validate(result)
-        return res
+        return res, None
 
-    async def get_flight(self, flight_id: int) -> Optional[models.Flight]:
+    async def get_flight(
+        self, flight_id: int
+    ) -> tuple[Optional[models.Flight], Optional[str]]:
         loop = asyncio.get_running_loop()
-        res = await loop.run_in_executor(None, self.get_flight_sync, flight_id)
-        return res
+        res, sql = await loop.run_in_executor(None, self.get_flight_sync, flight_id)
+        return res, sql
 
     def search_flights_by_number_sync(
         self,
         airline: str,
         number: str,
-    ) -> list[models.Flight]:
+    ) -> tuple[list[models.Flight], Optional[str]]:
         with self.__pool.connect() as conn:
             s = text(
                 """
@@ -576,25 +592,25 @@ class Client(datastore.Client[Config]):
             results = (conn.execute(s, parameters=params)).mappings().fetchall()
 
         res = [models.Flight.model_validate(r) for r in results]
-        return res
+        return res, None
 
     async def search_flights_by_number(
         self,
         airline: str,
         number: str,
-    ) -> list[models.Flight]:
+    ) -> tuple[list[models.Flight], Optional[str]]:
         loop = asyncio.get_running_loop()
-        res = await loop.run_in_executor(
+        res, sql = await loop.run_in_executor(
             None, self.search_flights_by_number_sync, airline, number
         )
-        return res
+        return res, sql
 
     def search_flights_by_airports_sync(
         self,
         date: str,
         departure_airport: Optional[str] = None,
         arrival_airport: Optional[str] = None,
-    ) -> list[models.Flight]:
+    ) -> tuple[list[models.Flight], Optional[str]]:
         with self.__pool.connect() as conn:
             s = text(
                 """
@@ -615,23 +631,23 @@ class Client(datastore.Client[Config]):
             results = (conn.execute(s, parameters=params)).mappings().fetchall()
 
         res = [models.Flight.model_validate(r) for r in results]
-        return res
+        return res, None
 
     async def search_flights_by_airports(
         self,
         date: str,
         departure_airport: Optional[str] = None,
         arrival_airport: Optional[str] = None,
-    ) -> list[models.Flight]:
+    ) -> tuple[list[models.Flight], Optional[str]]:
         loop = asyncio.get_running_loop()
-        res = await loop.run_in_executor(
+        res, sql = await loop.run_in_executor(
             None,
             self.search_flights_by_airports_sync,
             date,
             departure_airport,
             arrival_airport,
         )
-        return res
+        return res, sql
 
     def validate_ticket_sync(
         self,
@@ -639,7 +655,7 @@ class Client(datastore.Client[Config]):
         flight_number: str,
         departure_airport: str,
         departure_time: str,
-    ) -> Optional[models.Flight]:
+    ) -> tuple[Optional[models.Flight], Optional[str]]:
         with self.__pool.connect() as conn:
             s = text(
                 """
@@ -660,9 +676,9 @@ class Client(datastore.Client[Config]):
 
             result = (conn.execute(s, parameters=params)).mappings().fetchone()
         if result is None:
-            return None
+            return None, None
         res = models.Flight.model_validate(result)
-        return res
+        return res, None
 
     async def validate_ticket(
         self,
@@ -670,9 +686,9 @@ class Client(datastore.Client[Config]):
         flight_number: str,
         departure_airport: str,
         departure_time: str,
-    ) -> Optional[models.Flight]:
+    ) -> tuple[Optional[models.Flight], Optional[str]]:
         loop = asyncio.get_running_loop()
-        res = await loop.run_in_executor(
+        res, sql = await loop.run_in_executor(
             None,
             self.validate_ticket_sync,
             airline,
@@ -680,7 +696,7 @@ class Client(datastore.Client[Config]):
             departure_airport,
             departure_time,
         )
-        return res
+        return res, sql
 
     def insert_ticket_sync(
         self,
@@ -763,7 +779,7 @@ class Client(datastore.Client[Config]):
     def list_tickets_sync(
         self,
         user_id: str,
-    ) -> list[models.Ticket]:
+    ) -> tuple[list[models.Ticket], Optional[str]]:
         with self.__pool.connect() as conn:
             s = text(
                 """
@@ -778,19 +794,19 @@ class Client(datastore.Client[Config]):
             results = (conn.execute(s, parameters=params)).mappings().fetchall()
 
         res = [models.Ticket.model_validate(r) for r in results]
-        return res
+        return res, None
 
     async def list_tickets(
         self,
         user_id: str,
-    ) -> list[models.Ticket]:
+    ) -> tuple[list[models.Ticket], Optional[str]]:
         loop = asyncio.get_running_loop()
-        res = await loop.run_in_executor(None, self.list_tickets_sync, user_id)
-        return res
+        res, sql = await loop.run_in_executor(None, self.list_tickets_sync, user_id)
+        return res, sql
 
     def policies_search_sync(
         self, query_embedding: list[float], similarity_threshold: float, top_k: int
-    ) -> list[str]:
+    ) -> tuple[list[str], Optional[str]]:
         with self.__pool.connect() as conn:
             s = text(
                 """
@@ -807,20 +823,20 @@ class Client(datastore.Client[Config]):
             results = (conn.execute(s, parameters=params)).mappings().fetchall()
 
         res = [r["content"] for r in results]
-        return res
+        return res, None
 
     async def policies_search(
         self, query_embedding: list[float], similarity_threshold: float, top_k: int
-    ) -> list[str]:
+    ) -> tuple[list[str], Optional[str]]:
         loop = asyncio.get_running_loop()
-        res = await loop.run_in_executor(
+        res, sql = await loop.run_in_executor(
             None,
             self.policies_search_sync,
             query_embedding,
             similarity_threshold,
             top_k,
         )
-        return res
+        return res, sql
 
     async def close(self):
         self.__pool.dispose()

--- a/retrieval_service/datastore/providers/cloudsql_mysql_test.py
+++ b/retrieval_service/datastore/providers/cloudsql_mysql_test.py
@@ -204,7 +204,7 @@ async def test_export_dataset(ds: cloudsql_mysql.Client):
 
 
 async def test_get_airport_by_id(ds: cloudsql_mysql.Client):
-    res = await ds.get_airport_by_id(1)
+    res, sql = await ds.get_airport_by_id(1)
     expected = models.Airport(
         id=1,
         iata="MAG",
@@ -213,6 +213,7 @@ async def test_get_airport_by_id(ds: cloudsql_mysql.Client):
         country="Papua New Guinea",
     )
     assert res == expected
+    assert sql is None
 
 
 @pytest.mark.parametrize(
@@ -223,7 +224,7 @@ async def test_get_airport_by_id(ds: cloudsql_mysql.Client):
     ],
 )
 async def test_get_airport_by_iata(ds: cloudsql_mysql.Client, iata: str):
-    res = await ds.get_airport_by_iata(iata)
+    res, sql = await ds.get_airport_by_iata(iata)
     expected = models.Airport(
         id=3270,
         iata="SFO",
@@ -232,6 +233,7 @@ async def test_get_airport_by_iata(ds: cloudsql_mysql.Client, iata: str):
         country="United States",
     )
     assert res == expected
+    assert sql is None
 
 
 search_airports_test_data = [
@@ -319,12 +321,13 @@ async def test_search_airports(
     name: str,
     expected: List[models.Airport],
 ):
-    res = await ds.search_airports(country, city, name)
+    res, sql = await ds.search_airports(country, city, name)
     assert res == expected
+    assert sql is None
 
 
 async def test_get_amenity(ds: cloudsql_mysql.Client):
-    res = await ds.get_amenity(0)
+    res, sql = await ds.get_amenity(0)
     expected = models.Amenity(
         id=0,
         name="Coffee Shop 732",
@@ -349,6 +352,7 @@ async def test_get_amenity(ds: cloudsql_mysql.Client):
         saturday_end_hour=None,
     )
     assert res == expected
+    assert sql is None
 
 
 amenities_search_test_data = [
@@ -407,12 +411,13 @@ async def test_amenities_search(
     top_k: int,
     expected: List[Any],
 ):
-    res = await ds.amenities_search(query_embedding, similarity_threshold, top_k)
+    res, sql = await ds.amenities_search(query_embedding, similarity_threshold, top_k)
     assert res == expected
+    assert sql is None
 
 
 async def test_get_flight(ds: cloudsql_mysql.Client):
-    res = await ds.get_flight(1)
+    res, sql = await ds.get_flight(1)
     expected = models.Flight(
         id=1,
         airline="UA",
@@ -425,6 +430,7 @@ async def test_get_flight(ds: cloudsql_mysql.Client):
         arrival_gate="D30",
     )
     assert res == expected
+    assert sql is None
 
 
 search_flights_by_number_test_data = [
@@ -483,8 +489,9 @@ async def test_search_flights_by_number(
     number: str,
     expected: List[models.Flight],
 ):
-    res = await ds.search_flights_by_number(airline, number)
+    res, sql = await ds.search_flights_by_number(airline, number)
     assert res == expected
+    assert sql is None
 
 
 search_flights_by_airports_test_data = [
@@ -607,8 +614,11 @@ async def test_search_flights_by_airports(
     arrival_airport: str,
     expected: List[models.Flight],
 ):
-    res = await ds.search_flights_by_airports(date, departure_airport, arrival_airport)
+    res, sql = await ds.search_flights_by_airports(
+        date, departure_airport, arrival_airport
+    )
     assert res == expected
+    assert sql is None
 
 
 async def test_insert_ticket(ds: cloudsql_mysql.Client):
@@ -626,7 +636,7 @@ async def test_insert_ticket(ds: cloudsql_mysql.Client):
 
 
 async def test_list_tickets(ds: cloudsql_mysql.Client):
-    res = await ds.list_tickets("1")
+    res, sql = await ds.list_tickets("1")
     expected = models.Ticket(
         user_id=1,
         user_name="test",
@@ -639,10 +649,11 @@ async def test_list_tickets(ds: cloudsql_mysql.Client):
         arrival_time=datetime.strptime("2024-01-01 09:23:00", "%Y-%m-%d %H:%M:%S"),
     )
     assert res == [expected]
+    assert sql is None
 
 
 async def test_validate_ticket(ds: cloudsql_mysql.Client):
-    res = await ds.validate_ticket("UA", "1532", "SFO", "2024-01-01 05:50:00")
+    res, sql = await ds.validate_ticket("UA", "1532", "SFO", "2024-01-01 05:50:00")
     expected = models.Flight(
         id=0,
         airline="UA",
@@ -655,6 +666,7 @@ async def test_validate_ticket(ds: cloudsql_mysql.Client):
         arrival_gate="D6",
     )
     assert res == expected
+    assert sql is None
 
 
 policies_search_test_data = [
@@ -692,5 +704,6 @@ async def test_policies_search(
     top_k: int,
     expected: List[str],
 ):
-    res = await ds.policies_search(query_embedding, similarity_threshold, top_k)
+    res, sql = await ds.policies_search(query_embedding, similarity_threshold, top_k)
     assert res == expected
+    assert sql is None

--- a/retrieval_service/datastore/providers/cloudsql_postgres.py
+++ b/retrieval_service/datastore/providers/cloudsql_postgres.py
@@ -520,9 +520,9 @@ class Client(datastore.Client[Config]):
             result = (await conn.execute(s, params)).mappings().fetchone()
 
         if result is None:
-            return None
+            return None, None
         res = models.Flight.model_validate(result)
-        return res
+        return res, None
 
     async def insert_ticket(
         self,

--- a/retrieval_service/datastore/providers/cloudsql_postgres.py
+++ b/retrieval_service/datastore/providers/cloudsql_postgres.py
@@ -327,36 +327,40 @@ class Client(datastore.Client[Config]):
 
             return airports, amenities, flights, policies
 
-    async def get_airport_by_id(self, id: int) -> Optional[models.Airport]:
+    async def get_airport_by_id(
+        self, id: int
+    ) -> tuple[Optional[models.Airport], Optional[str]]:
         async with self.__pool.connect() as conn:
             s = text("""SELECT * FROM airports WHERE id=:id""")
             params = {"id": id}
             result = (await conn.execute(s, params)).mappings().fetchone()
 
         if result is None:
-            return None
+            return None, None
 
         res = models.Airport.model_validate(result)
-        return res
+        return res, None
 
-    async def get_airport_by_iata(self, iata: str) -> Optional[models.Airport]:
+    async def get_airport_by_iata(
+        self, iata: str
+    ) -> tuple[Optional[models.Airport], Optional[str]]:
         async with self.__pool.connect() as conn:
             s = text("""SELECT * FROM airports WHERE iata ILIKE :iata""")
             params = {"iata": iata}
             result = (await conn.execute(s, params)).mappings().fetchone()
 
         if result is None:
-            return None
+            return None, None
 
         res = models.Airport.model_validate(result)
-        return res
+        return res, None
 
     async def search_airports(
         self,
         country: Optional[str] = None,
         city: Optional[str] = None,
         name: Optional[str] = None,
-    ) -> list[models.Airport]:
+    ) -> tuple[list[models.Airport], Optional[str]]:
         async with self.__pool.connect() as conn:
             s = text(
                 """
@@ -375,9 +379,11 @@ class Client(datastore.Client[Config]):
             results = (await conn.execute(s, params)).mappings().fetchall()
 
         res = [models.Airport.model_validate(r) for r in results]
-        return res
+        return res, None
 
-    async def get_amenity(self, id: int) -> Optional[models.Amenity]:
+    async def get_amenity(
+        self, id: int
+    ) -> tuple[Optional[models.Amenity], Optional[str]]:
         async with self.__pool.connect() as conn:
             s = text(
                 """
@@ -389,14 +395,14 @@ class Client(datastore.Client[Config]):
             result = (await conn.execute(s, params)).mappings().fetchone()
 
         if result is None:
-            return None
+            return None, None
 
         res = models.Amenity.model_validate(result)
-        return res
+        return res, None
 
     async def amenities_search(
         self, query_embedding: list[float], similarity_threshold: float, top_k: int
-    ) -> list[Any]:
+    ) -> tuple[list[Any], Optional[str]]:
         async with self.__pool.connect() as conn:
             s = text(
                 """
@@ -415,9 +421,11 @@ class Client(datastore.Client[Config]):
             results = (await conn.execute(s, params)).mappings().fetchall()
 
         res = [r for r in results]
-        return res
+        return res, None
 
-    async def get_flight(self, flight_id: int) -> Optional[models.Flight]:
+    async def get_flight(
+        self, flight_id: int
+    ) -> tuple[Optional[models.Flight], Optional[str]]:
         async with self.__pool.connect() as conn:
             s = text(
                 """
@@ -429,16 +437,16 @@ class Client(datastore.Client[Config]):
             result = (await conn.execute(s, params)).mappings().fetchone()
 
         if result is None:
-            return None
+            return None, None
 
         res = models.Flight.model_validate(result)
-        return res
+        return res, None
 
     async def search_flights_by_number(
         self,
         airline: str,
         number: str,
-    ) -> list[models.Flight]:
+    ) -> tuple[list[models.Flight], Optional[str]]:
         async with self.__pool.connect() as conn:
             s = text(
                 """
@@ -455,14 +463,14 @@ class Client(datastore.Client[Config]):
             results = (await conn.execute(s, params)).mappings().fetchall()
 
         res = [models.Flight.model_validate(r) for r in results]
-        return res
+        return res, None
 
     async def search_flights_by_airports(
         self,
         date: str,
         departure_airport: Optional[str] = None,
         arrival_airport: Optional[str] = None,
-    ) -> list[models.Flight]:
+    ) -> tuple[list[models.Flight], Optional[str]]:
         async with self.__pool.connect() as conn:
             s = text(
                 """
@@ -483,7 +491,7 @@ class Client(datastore.Client[Config]):
             results = (await conn.execute(s, params)).mappings().fetchall()
 
         res = [models.Flight.model_validate(r) for r in results]
-        return res
+        return res, None
 
     async def validate_ticket(
         self,
@@ -491,7 +499,7 @@ class Client(datastore.Client[Config]):
         flight_number: str,
         departure_airport: str,
         departure_time: str,
-    ) -> Optional[models.Flight]:
+    ) -> tuple[Optional[models.Flight], Optional[str]]:
         departure_time_datetime = datetime.strptime(departure_time, "%Y-%m-%d %H:%M:%S")
         async with self.__pool.connect() as conn:
             s = text(
@@ -576,7 +584,7 @@ class Client(datastore.Client[Config]):
     async def list_tickets(
         self,
         user_id: str,
-    ) -> list[models.Ticket]:
+    ) -> tuple[list[models.Ticket], Optional[str]]:
         async with self.__pool.connect() as conn:
             s = text(
                 """
@@ -590,11 +598,11 @@ class Client(datastore.Client[Config]):
             results = (await conn.execute(s, params)).mappings().fetchall()
 
         res = [models.Ticket.model_validate(r) for r in results]
-        return res
+        return res, None
 
     async def policies_search(
         self, query_embedding: list[float], similarity_threshold: float, top_k: int
-    ) -> list[str]:
+    ) -> tuple[list[str], Optional[str]]:
         async with self.__pool.connect() as conn:
             s = text(
                 """
@@ -613,7 +621,7 @@ class Client(datastore.Client[Config]):
             results = (await conn.execute(s, params)).mappings().fetchall()
 
         res = [r["content"] for r in results]
-        return res
+        return res, None
 
     async def close(self):
         await self.__pool.dispose()

--- a/retrieval_service/datastore/providers/cloudsql_postgres_test.py
+++ b/retrieval_service/datastore/providers/cloudsql_postgres_test.py
@@ -190,7 +190,7 @@ async def test_export_dataset(ds: cloudsql_postgres.Client):
 
 
 async def test_get_airport_by_id(ds: cloudsql_postgres.Client):
-    res = await ds.get_airport_by_id(1)
+    res, sql = await ds.get_airport_by_id(1)
     expected = models.Airport(
         id=1,
         iata="MAG",
@@ -199,6 +199,7 @@ async def test_get_airport_by_id(ds: cloudsql_postgres.Client):
         country="Papua New Guinea",
     )
     assert res == expected
+    assert sql is None
 
 
 @pytest.mark.parametrize(
@@ -209,7 +210,7 @@ async def test_get_airport_by_id(ds: cloudsql_postgres.Client):
     ],
 )
 async def test_get_airport_by_iata(ds: cloudsql_postgres.Client, iata: str):
-    res = await ds.get_airport_by_iata(iata)
+    res, sql = await ds.get_airport_by_iata(iata)
     expected = models.Airport(
         id=3270,
         iata="SFO",
@@ -218,6 +219,7 @@ async def test_get_airport_by_iata(ds: cloudsql_postgres.Client, iata: str):
         country="United States",
     )
     assert res == expected
+    assert sql is None
 
 
 search_airports_test_data = [
@@ -298,12 +300,13 @@ async def test_search_airports(
     name: str,
     expected: List[models.Airport],
 ):
-    res = await ds.search_airports(country, city, name)
+    res, sql = await ds.search_airports(country, city, name)
     assert res == expected
+    assert sql is None
 
 
 async def test_get_amenity(ds: cloudsql_postgres.Client):
-    res = await ds.get_amenity(0)
+    res, sql = await ds.get_amenity(0)
     expected = models.Amenity(
         id=0,
         name="Coffee Shop 732",
@@ -328,6 +331,7 @@ async def test_get_amenity(ds: cloudsql_postgres.Client):
         saturday_end_hour=None,
     )
     assert res == expected
+    assert sql is None
 
 
 amenities_search_test_data = [
@@ -394,12 +398,13 @@ async def test_amenities_search(
     top_k: int,
     expected: List[Any],
 ):
-    res = await ds.amenities_search(query_embedding, similarity_threshold, top_k)
+    res, sql = await ds.amenities_search(query_embedding, similarity_threshold, top_k)
     assert res == expected
+    assert sql is None
 
 
 async def test_get_flight(ds: cloudsql_postgres.Client):
-    res = await ds.get_flight(1)
+    res, sql = await ds.get_flight(1)
     expected = models.Flight(
         id=1,
         airline="UA",
@@ -412,6 +417,7 @@ async def test_get_flight(ds: cloudsql_postgres.Client):
         arrival_gate="D30",
     )
     assert res == expected
+    assert sql is None
 
 
 search_flights_by_number_test_data = [
@@ -470,8 +476,9 @@ async def test_search_flights_by_number(
     number: str,
     expected: List[models.Flight],
 ):
-    res = await ds.search_flights_by_number(airline, number)
+    res, sql = await ds.search_flights_by_number(airline, number)
     assert res == expected
+    assert sql is None
 
 
 search_flights_by_airports_test_data = [
@@ -594,8 +601,11 @@ async def test_search_flights_by_airports(
     arrival_airport: str,
     expected: List[models.Flight],
 ):
-    res = await ds.search_flights_by_airports(date, departure_airport, arrival_airport)
+    res, sql = await ds.search_flights_by_airports(
+        date, departure_airport, arrival_airport
+    )
     assert res == expected
+    assert sql is None
 
 
 async def test_insert_ticket(ds: cloudsql_postgres.Client):
@@ -687,5 +697,6 @@ async def test_policies_search(
     top_k: int,
     expected: List[str],
 ):
-    res = await ds.policies_search(query_embedding, similarity_threshold, top_k)
+    res, sql = await ds.policies_search(query_embedding, similarity_threshold, top_k)
     assert res == expected
+    assert sql is None

--- a/retrieval_service/datastore/providers/firestore.py
+++ b/retrieval_service/datastore/providers/firestore.py
@@ -351,28 +351,32 @@ class Client(datastore.Client[Config]):
 
         return airports, amenities, flights, policies
 
-    async def get_airport_by_id(self, id: int) -> Optional[models.Airport]:
+    async def get_airport_by_id(
+        self, id: int
+    ) -> tuple[Optional[models.Airport], Optional[str]]:
         query = self.__client.collection("airports").where(
             filter=FieldFilter("id", "==", id)
         )
         airport_doc = await query.get()
         airport_dict = airport_doc.to_dict() | {"id": airport_doc.id}
-        return models.Airport.model_validate(airport_dict)
+        return models.Airport.model_validate(airport_dict), None
 
-    async def get_airport_by_iata(self, iata: str) -> Optional[models.Airport]:
+    async def get_airport_by_iata(
+        self, iata: str
+    ) -> tuple[Optional[models.Airport], Optional[str]]:
         query = self.__client.collection("airports").where(
             filter=FieldFilter("iata", "==", iata)
         )
         airport_doc = await query.get()
         airport_dict = airport_doc.to_dict() | {"id": airport_doc.id}
-        return models.Airport.model_validate(airport_dict)
+        return models.Airport.model_validate(airport_dict), None
 
     async def search_airports(
         self,
         country: Optional[str] = None,
         city: Optional[str] = None,
         name: Optional[str] = None,
-    ) -> list[models.Airport]:
+    ) -> tuple[list[models.Airport], Optional[str]]:
         query = self.__client.collection("airports")
 
         if country is not None:
@@ -391,9 +395,11 @@ class Client(datastore.Client[Config]):
         async for doc in docs:
             airport_dict = doc.to_dict() | {"id": doc.id}
             airports.append(models.Airport.model_validate(airport_dict))
-        return airports
+        return airports, None
 
-    async def get_amenity(self, id: int) -> Optional[models.Amenity]:
+    async def get_amenity(
+        self, id: int
+    ) -> tuple[Optional[models.Amenity], Optional[str]]:
         query = self.__client.collection("amenities").where(
             filter=FieldFilter("id", "==", id)
         )
@@ -404,7 +410,7 @@ class Client(datastore.Client[Config]):
 
     async def amenities_search(
         self, query_embedding: list[float], similarity_threshold: float, top_k: int
-    ) -> list[Any]:
+    ) -> tuple[list[Any], Optional[str]]:
         # Using the same similarity metric to the embedding model's training method
         # produce the most accurate result
         query = self.__amenities_collection.find_nearest(
@@ -427,21 +433,23 @@ class Client(datastore.Client[Config]):
                 "terminal": doc.get("terminal"),
             }
             amenities.append(amenity_dict)
-        return amenities
+        return amenities, None
 
-    async def get_flight(self, flight_id: int) -> Optional[models.Flight]:
+    async def get_flight(
+        self, flight_id: int
+    ) -> tuple[Optional[models.Flight], Optional[str]]:
         query = self.__client.collection("flights").where(
             filter=FieldFilter("id", "==", flight_id)
         )
         flight_doc = await query.get()
         flight_dict = flight_doc.to_dict() | {"id": flight_doc.id}
-        return models.Flight.model_validate(flight_dict)
+        return models.Flight.model_validate(flight_dict), None
 
     async def search_flights_by_number(
         self,
         airline: str,
         number: str,
-    ) -> list[models.Flight]:
+    ) -> tuple[list[models.Flight], Optional[str]]:
         query = (
             self.__client.collection("flights")
             .where(filter=FieldFilter("airline", "==", airline))
@@ -454,14 +462,14 @@ class Client(datastore.Client[Config]):
         async for doc in docs:
             flight_dict = doc.to_dict() | {"id": doc.id}
             flights.append(models.Flight.model_validate(flight_dict))
-        return flights
+        return flights, None
 
     async def search_flights_by_airports(
         self,
         date: str,
         departure_airport: Optional[str] = None,
         arrival_airport: Optional[str] = None,
-    ) -> list[models.Flight]:
+    ) -> tuple[list[models.Flight], Optional[str]]:
         date_obj = datetime.strptime(date, "%Y-%m-%d").date()
         date_timestamp = datetime.combine(date_obj, datetime.min.time())
         query = (
@@ -481,7 +489,7 @@ class Client(datastore.Client[Config]):
         async for doc in docs:
             flight_dict = doc.to_dict() | {"id": doc.id}
             flights.append(models.Flight.model_validate(flight_dict))
-        return flights
+        return flights, None
 
     async def validate_ticket(
         self,
@@ -489,7 +497,7 @@ class Client(datastore.Client[Config]):
         flight_number: str,
         departure_airport: str,
         departure_time: str,
-    ) -> Optional[models.Flight]:
+    ) -> tuple[Optional[models.Flight], Optional[str]]:
         raise NotImplementedError("Not Implemented")
 
     async def insert_ticket(
@@ -509,12 +517,12 @@ class Client(datastore.Client[Config]):
     async def list_tickets(
         self,
         user_id: str,
-    ) -> list[models.Ticket]:
+    ) -> tuple[list[models.Ticket], Optional[str]]:
         raise NotImplementedError("Not Implemented")
 
     async def policies_search(
         self, query_embedding: list[float], similarity_threshold: float, top_k: int
-    ) -> list[Any]:
+    ) -> tuple[list[str], Optional[str]]:
         query = self.__policies_collection.find_nearest(
             vector_field="embedding",
             query_vector=Vector(query_embedding),
@@ -526,7 +534,7 @@ class Client(datastore.Client[Config]):
         async for doc in query.stream():
             policy_dict = {"id": doc.id, "content": doc.get("content")}
             policies.append(policy_dict)
-        return policies
+        return policies, None
 
     async def close(self):
         self.__client.close()

--- a/retrieval_service/datastore/providers/firestore.py
+++ b/retrieval_service/datastore/providers/firestore.py
@@ -406,7 +406,7 @@ class Client(datastore.Client[Config]):
         amenity_doc = await query.get()
         amenity_dict = amenity_doc.to_dict() | {"id": amenity_doc.id}
         amenity_dict["embedding"] = list(amenity_dict["embedding"])
-        return models.Amenity.model_validate(amenity_dict)
+        return models.Amenity.model_validate(amenity_dict), None
 
     async def amenities_search(
         self, query_embedding: list[float], similarity_threshold: float, top_k: int
@@ -532,8 +532,7 @@ class Client(datastore.Client[Config]):
 
         policies = []
         async for doc in query.stream():
-            policy_dict = {"id": doc.id, "content": doc.get("content")}
-            policies.append(policy_dict)
+            policies.append(doc.get("content"))
         return policies, None
 
     async def close(self):

--- a/retrieval_service/datastore/providers/neo4j_graph.py
+++ b/retrieval_service/datastore/providers/neo4j_graph.py
@@ -99,10 +99,14 @@ class Client(datastore.Client[Config]):
     ]:
         raise NotImplementedError("This client does not support airports.")
 
-    async def get_airport_by_id(self, id: int) -> Optional[models.Airport]:
+    async def get_airport_by_id(
+        self, id: int
+    ) -> tuple[Optional[models.Airport], Optional[str]]:
         raise NotImplementedError("This client does not support airports.")
 
-    async def get_airport_by_iata(self, iata: str) -> Optional[models.Airport]:
+    async def get_airport_by_iata(
+        self, iata: str
+    ) -> tuple[Optional[models.Airport], Optional[str]]:
         raise NotImplementedError("This client does not support airports.")
 
     async def search_airports(
@@ -110,10 +114,12 @@ class Client(datastore.Client[Config]):
         country: Optional[str] = None,
         city: Optional[str] = None,
         name: Optional[str] = None,
-    ) -> list[models.Airport]:
+    ) -> tuple[list[models.Airport], Optional[str]]:
         raise NotImplementedError("This client does not support airports.")
 
-    async def get_amenity(self, id: int) -> Optional[models.Amenity]:
+    async def get_amenity(
+        self, id: int
+    ) -> tuple[Optional[models.Amenity], Optional[str]]:
         async with self.__driver.session() as session:
             result = await session.run(
                 "MATCH (amenity: Amenity {id: $id}) RETURN amenity", id=id
@@ -121,22 +127,24 @@ class Client(datastore.Client[Config]):
             record = await result.single()
 
             if not record:
-                return None
+                return None, None
 
             amenity_data = record["amenity"]
-            return models.Amenity(**amenity_data)
+            return models.Amenity(**amenity_data), None
 
     async def amenities_search(
         self, query_embedding: list[float], similarity_threshold: float, top_k: int
-    ) -> list[dict]:
+    ) -> tuple[list[dict], Optional[str]]:
         raise NotImplementedError("This client does not support amenities.")
 
-    async def get_flight(self, flight_id: int) -> Optional[models.Flight]:
+    async def get_flight(
+        self, flight_id: int
+    ) -> tuple[Optional[models.Flight], Optional[str]]:
         raise NotImplementedError("This client does not support flights.")
 
     async def search_flights_by_number(
         self, airline: str, flight_number: str
-    ) -> list[models.Flight]:
+    ) -> tuple[list[models.Flight], Optional[str]]:
         raise NotImplementedError("This client does not support flights.")
 
     async def search_flights_by_airports(
@@ -144,7 +152,7 @@ class Client(datastore.Client[Config]):
         date,
         departure_airport: Optional[str] = None,
         arrival_airport: Optional[str] = None,
-    ) -> list[models.Flight]:
+    ) -> tuple[list[models.Flight], Optional[str]]:
         raise NotImplementedError("This client does not support flights.")
 
     async def validate_ticket(
@@ -153,7 +161,7 @@ class Client(datastore.Client[Config]):
         flight_number: str,
         departure_airport: str,
         departure_time: str,
-    ) -> Optional[models.Flight]:
+    ) -> tuple[Optional[models.Flight], Optional[str]]:
         raise NotImplementedError("This client does not support tickets.")
 
     async def insert_ticket(
@@ -170,12 +178,14 @@ class Client(datastore.Client[Config]):
     ):
         raise NotImplementedError("This client does not support tickets.")
 
-    async def list_tickets(self, user_id: str) -> list[models.Ticket]:
+    async def list_tickets(
+        self, user_id: str
+    ) -> tuple[list[models.Ticket], Optional[str]]:
         raise NotImplementedError("This client does not support tickets.")
 
     async def policies_search(
         self, query_embedding: list[float], similarity_threshold: float, top_k: int
-    ) -> list[str]:
+    ) -> tuple[list[str], Optional[str]]:
         raise NotImplementedError("This client does not support policies.")
 
     async def close(self):

--- a/retrieval_service/datastore/providers/neo4j_graph_test.py
+++ b/retrieval_service/datastore/providers/neo4j_graph_test.py
@@ -93,7 +93,7 @@ async def test_total_amenity_nodes_count(ds: neo4j_graph.Client):
 
 
 async def get_amenity_id(ds: neo4j_graph.Client):
-    amenity = await ds.get_amenity(35)
+    amenity, sql = await ds.get_amenity(35)
 
     assert amenity, f"No amenity found with id 35"
 

--- a/retrieval_service/datastore/providers/postgres_test.py
+++ b/retrieval_service/datastore/providers/postgres_test.py
@@ -143,7 +143,7 @@ async def test_export_dataset(ds: postgres.Client):
 
 
 async def test_get_airport_by_id(ds: postgres.Client):
-    res = await ds.get_airport_by_id(1)
+    res, sql = await ds.get_airport_by_id(1)
     expected = models.Airport(
         id=1,
         iata="MAG",
@@ -152,6 +152,7 @@ async def test_get_airport_by_id(ds: postgres.Client):
         country="Papua New Guinea",
     )
     assert res == expected
+    assert sql is not None
 
 
 @pytest.mark.parametrize(
@@ -162,7 +163,7 @@ async def test_get_airport_by_id(ds: postgres.Client):
     ],
 )
 async def test_get_airport_by_iata(ds: postgres.Client, iata: str):
-    res = await ds.get_airport_by_iata(iata)
+    res, sql = await ds.get_airport_by_iata(iata)
     expected = models.Airport(
         id=3270,
         iata="SFO",
@@ -171,6 +172,7 @@ async def test_get_airport_by_iata(ds: postgres.Client, iata: str):
         country="United States",
     )
     assert res == expected
+    assert sql is not None
 
 
 search_airports_test_data = [
@@ -251,12 +253,13 @@ async def test_search_airports(
     name: str,
     expected: List[models.Airport],
 ):
-    res = await ds.search_airports(country, city, name)
+    res, sql = await ds.search_airports(country, city, name)
     assert res == expected
+    assert sql is not None
 
 
 async def test_get_amenity(ds: postgres.Client):
-    res = await ds.get_amenity(0)
+    res, sql = await ds.get_amenity(0)
     expected = models.Amenity(
         id=0,
         name="Coffee Shop 732",
@@ -281,6 +284,7 @@ async def test_get_amenity(ds: postgres.Client):
         saturday_end_hour=None,
     )
     assert res == expected
+    assert sql is not None
 
 
 amenities_search_test_data = [
@@ -347,12 +351,13 @@ async def test_amenities_search(
     top_k: int,
     expected: List[Any],
 ):
-    res = await ds.amenities_search(query_embedding, similarity_threshold, top_k)
+    res, sql = await ds.amenities_search(query_embedding, similarity_threshold, top_k)
     assert res == expected
+    assert sql is not None
 
 
 async def test_get_flight(ds: postgres.Client):
-    res = await ds.get_flight(1)
+    res, sql = await ds.get_flight(1)
     expected = models.Flight(
         id=1,
         airline="UA",
@@ -365,6 +370,7 @@ async def test_get_flight(ds: postgres.Client):
         arrival_gate="D30",
     )
     assert res == expected
+    assert sql is not None
 
 
 search_flights_by_number_test_data = [
@@ -420,8 +426,9 @@ search_flights_by_number_test_data = [
 async def test_search_flights_by_number(
     ds: postgres.Client, airline: str, number: str, expected: List[models.Flight]
 ):
-    res = await ds.search_flights_by_number(airline, number)
+    res, sql = await ds.search_flights_by_number(airline, number)
     assert res == expected
+    assert sql is not None
 
 
 search_flights_by_airports_test_data = [
@@ -544,8 +551,11 @@ async def test_search_flights_by_airports(
     arrival_airport: str,
     expected: List[models.Flight],
 ):
-    res = await ds.search_flights_by_airports(date, departure_airport, arrival_airport)
+    res, sql = await ds.search_flights_by_airports(
+        date, departure_airport, arrival_airport
+    )
     assert res == expected
+    assert sql is not None
 
 
 policies_search_test_data = [
@@ -591,5 +601,6 @@ async def test_policies_search(
     top_k: int,
     expected: List[str],
 ):
-    res = await ds.policies_search(query_embedding, similarity_threshold, top_k)
+    res, sql = await ds.policies_search(query_embedding, similarity_threshold, top_k)
     assert res == expected
+    assert sql is not None

--- a/retrieval_service/datastore/providers/spanner_gsql.py
+++ b/retrieval_service/datastore/providers/spanner_gsql.py
@@ -482,7 +482,9 @@ class Client(datastore.Client[Config]):
 
         return airports, amenities, flights, policies
 
-    async def get_airport_by_id(self, id: int) -> Optional[models.Airport]:
+    async def get_airport_by_id(
+        self, id: int
+    ) -> tuple[Optional[models.Airport], Optional[str]]:
         """
         Retrieve an airport by its ID.
 
@@ -502,7 +504,7 @@ class Client(datastore.Client[Config]):
 
         # Check if result is None
         if result is None:
-            return None
+            return None, None
 
         # Convert query result to model instance using model_validate method
         airports = [
@@ -512,9 +514,11 @@ class Client(datastore.Client[Config]):
             for a in result
         ]
 
-        return airports[0]
+        return airports[0], None
 
-    async def get_airport_by_iata(self, iata: str) -> Optional[models.Airport]:
+    async def get_airport_by_iata(
+        self, iata: str
+    ) -> tuple[Optional[models.Airport], Optional[str]]:
         """
         Retrieve an airport by its IATA code.
 
@@ -534,7 +538,7 @@ class Client(datastore.Client[Config]):
 
         # Check if result is None
         if result is None:
-            return None
+            return None, None
 
         # Convert query result to model instance using model_validate method
         airports = [
@@ -544,14 +548,14 @@ class Client(datastore.Client[Config]):
             for a in result
         ]
 
-        return airports[0]
+        return airports[0], None
 
     async def search_airports(
         self,
         country: Optional[str] = None,
         city: Optional[str] = None,
         name: Optional[str] = None,
-    ) -> list[models.Airport]:
+    ) -> tuple[list[models.Airport], Optional[str]]:
         """
         Search for airports based on optional parameters.
 
@@ -595,9 +599,11 @@ class Client(datastore.Client[Config]):
             for a in results
         ]
 
-        return airports
+        return airports, None
 
-    async def get_amenity(self, id: int) -> Optional[models.Amenity]:
+    async def get_amenity(
+        self, id: int
+    ) -> tuple[Optional[models.Amenity], Optional[str]]:
         """
         Retrieves an amenity by its ID.
 
@@ -611,7 +617,7 @@ class Client(datastore.Client[Config]):
             # Spread SQL query for readability
             result = snapshot.execute_sql(
                 sql="""
-                SELECT * FROM amenities
+                SELECT id, name, description, location, terminal, category, hour FROM amenities
                 WHERE id = @id
                 """,
                 params={"id": id},
@@ -620,7 +626,7 @@ class Client(datastore.Client[Config]):
 
         # Check if result is None
         if result is None:
-            return None
+            return None, None
 
         # Convert query result to model instance using model_validate method
         amenities = [
@@ -630,11 +636,11 @@ class Client(datastore.Client[Config]):
             for a in result
         ]
 
-        return amenities[0]
+        return amenities[0], None
 
     async def amenities_search(
         self, query_embedding: list[float], similarity_threshold: float, top_k: int
-    ) -> list[Any]:
+    ) -> tuple[list[Any], Optional[str]]:
         """
         Search for amenities based on similarity to a query embedding.
 
@@ -681,9 +687,11 @@ class Client(datastore.Client[Config]):
             for a in results
         ]
 
-        return amenities
+        return amenities, None
 
-    async def get_flight(self, flight_id: int) -> Optional[models.Flight]:
+    async def get_flight(
+        self, flight_id: int
+    ) -> tuple[Optional[models.Flight], Optional[str]]:
         """
         Retrieves a flight by its ID.
 
@@ -705,7 +713,7 @@ class Client(datastore.Client[Config]):
             )
         # Check if result is None
         if result is None:
-            return None
+            return None, None
 
         # Convert query result to model instance using model_validate method
         flights = [
@@ -715,13 +723,13 @@ class Client(datastore.Client[Config]):
             for a in result
         ]
 
-        return flights[0]
+        return flights[0], None
 
     async def search_flights_by_number(
         self,
         airline: str,
         number: str,
-    ) -> list[models.Flight]:
+    ) -> tuple[list[models.Flight], Optional[str]]:
         """
         Search for flights by airline and flight number.
 
@@ -756,14 +764,14 @@ class Client(datastore.Client[Config]):
             for a in results
         ]
 
-        return flights
+        return flights, None
 
     async def search_flights_by_airports(
         self,
         date: str,
         departure_airport: Optional[str] = None,
         arrival_airport: Optional[str] = None,
-    ) -> list[models.Flight]:
+    ) -> tuple[list[models.Flight], Optional[str]]:
         """
         Search for flights by departure and/or arrival airports.
 
@@ -809,7 +817,7 @@ class Client(datastore.Client[Config]):
             for a in results
         ]
 
-        return flights
+        return flights, None
 
     async def validate_ticket(
         self,
@@ -817,7 +825,7 @@ class Client(datastore.Client[Config]):
         flight_number: str,
         departure_airport: str,
         departure_time: str,
-    ) -> Optional[models.Flight]:
+    ) -> tuple[Optional[models.Flight], Optional[str]]:
         departure_time_datetime = datetime.datetime.strptime(
             departure_time, "%Y-%m-%d %H:%M:%S"
         )
@@ -846,7 +854,7 @@ class Client(datastore.Client[Config]):
             )
 
         if results is None:
-            return None
+            return None, None
 
         flights = [
             models.Flight.model_validate(
@@ -854,7 +862,7 @@ class Client(datastore.Client[Config]):
             )
             for a in results
         ]
-        return flights[0]
+        return flights[0], None
 
     async def insert_ticket(
         self,
@@ -921,7 +929,7 @@ class Client(datastore.Client[Config]):
     async def list_tickets(
         self,
         user_id: str,
-    ) -> list[models.Ticket]:
+    ) -> tuple[list[models.Ticket], Optional[str]]:
         """
         Retrieves a list of tickets for a user.
 
@@ -963,11 +971,11 @@ class Client(datastore.Client[Config]):
             for a in results
         ]
 
-        return tickets
+        return tickets, None
 
     async def policies_search(
         self, query_embedding: list[float], similarity_threshold: float, top_k: int
-    ) -> list[str]:
+    ) -> tuple[list[str], Optional[str]]:
         """
         Search for policies based on similarity to a query embedding.
 
@@ -1009,7 +1017,7 @@ class Client(datastore.Client[Config]):
         # Convert query result to model instance using model_validate method
         policies = [a[0] for a in results]
 
-        return policies
+        return policies, None
 
     async def close(self):
         """

--- a/retrieval_service/datastore/providers/spanner_gsql_test.py
+++ b/retrieval_service/datastore/providers/spanner_gsql_test.py
@@ -164,7 +164,7 @@ async def test_export_dataset(ds: spanner_gsql.Client):
 
 
 async def test_get_airport_by_id(ds: spanner_gsql.Client):
-    res = await ds.get_airport_by_id(1)
+    res, sql = await ds.get_airport_by_id(1)
     expected = models.Airport(
         id=1,
         iata="MAG",
@@ -173,6 +173,7 @@ async def test_get_airport_by_id(ds: spanner_gsql.Client):
         country="Papua New Guinea",
     )
     assert res == expected
+    assert sql is None
 
 
 @pytest.mark.parametrize(
@@ -183,7 +184,7 @@ async def test_get_airport_by_id(ds: spanner_gsql.Client):
     ],
 )
 async def test_get_airport_by_iata(ds: spanner_gsql.Client, iata: str):
-    res = await ds.get_airport_by_iata(iata)
+    res, sql = await ds.get_airport_by_iata(iata)
     expected = models.Airport(
         id=3270,
         iata="SFO",
@@ -192,6 +193,7 @@ async def test_get_airport_by_iata(ds: spanner_gsql.Client, iata: str):
         country="United States",
     )
     assert res == expected
+    assert sql is None
 
 
 search_airports_test_data = [
@@ -272,12 +274,13 @@ async def test_search_airports(
     name: str,
     expected: List[models.Airport],
 ):
-    res = await ds.search_airports(country, city, name)
+    res, sql = await ds.search_airports(country, city, name)
     assert res == expected
+    assert sql is None
 
 
 async def test_get_amenity(ds: spanner_gsql.Client):
-    res: Optional[models.Amenity] = await ds.get_amenity(0)
+    res, sql = await ds.get_amenity(0)
     expected = models.Amenity(
         id=0,
         name="Coffee Shop 732",
@@ -302,13 +305,8 @@ async def test_get_amenity(ds: spanner_gsql.Client):
         saturday_end_hour=None,
     )
 
-    assert res is not None
-    assert res.name == expected.name
-    assert res.description == expected.description
-    assert res.location == expected.location
-    assert res.terminal == expected.terminal
-    assert res.category == expected.category
-    assert res.hour == expected.hour
+    assert res == expected
+    assert sql is None
 
 
 amenities_search_test_data = [
@@ -375,12 +373,13 @@ async def test_amenities_search(
     top_k: int,
     expected: List[models.Amenity],
 ):
-    res = await ds.amenities_search(query_embedding, similarity_threshold, top_k)
+    res, sql = await ds.amenities_search(query_embedding, similarity_threshold, top_k)
     assert res == expected
+    assert sql is None
 
 
 async def test_get_flight(ds: spanner_gsql.Client):
-    res = await ds.get_flight(1)
+    res, sql = await ds.get_flight(1)
     expected = models.Flight(
         id=1,
         airline="UA",
@@ -393,6 +392,7 @@ async def test_get_flight(ds: spanner_gsql.Client):
         arrival_gate="D30",
     )
     assert res == expected
+    assert sql is None
 
 
 search_flights_by_number_test_data = [
@@ -451,8 +451,9 @@ async def test_search_flights_by_number(
     number: str,
     expected: List[models.Flight],
 ):
-    res = await ds.search_flights_by_number(airline, number)
+    res, sql = await ds.search_flights_by_number(airline, number)
     assert res == expected
+    assert sql is None
 
 
 search_flights_by_airports_test_data = [
@@ -575,8 +576,11 @@ async def test_search_flights_by_airports(
     arrival_airport: str,
     expected: List[models.Flight],
 ):
-    res = await ds.search_flights_by_airports(date, departure_airport, arrival_airport)
+    res, sql = await ds.search_flights_by_airports(
+        date, departure_airport, arrival_airport
+    )
     assert res == expected
+    assert sql is None
 
 
 policies_search_test_data = [
@@ -622,5 +626,6 @@ async def test_policies_search(
     top_k: int,
     expected: List[models.Policy],
 ):
-    res = await ds.policies_search(query_embedding, similarity_threshold, top_k)
+    res, sql = await ds.policies_search(query_embedding, similarity_threshold, top_k)
     assert res == expected
+    assert sql is None


### PR DESCRIPTION
retrieval service to return results and sql query. Sql query will be used to display tracing at the frontend.

This PR only add sql return for postgres and alloydb provider. Other providers will be added in a separate PR.