### PR TITLE
fix: use lazy refresh for AlloyDB and Cloud SQL Connector

### DIFF
--- a/retrieval_service/datastore/providers/alloydb.py
+++ b/retrieval_service/datastore/providers/alloydb.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from typing import Any, Literal, Optional
 
 import asyncpg
-from google.cloud.alloydb.connector import AsyncConnector
+from google.cloud.alloydb.connector import AsyncConnector, RefreshStrategy
 from pgvector.asyncpg import register_vector
 from pydantic import BaseModel
 from sqlalchemy import text
@@ -54,7 +54,9 @@ class Client(datastore.Client[Config]):
     @classmethod
     async def create(cls, config: Config) -> "Client":
         async def getconn() -> asyncpg.Connection:
-            async with AsyncConnector() as connector:
+            async with AsyncConnector(
+                refresh_strategy=RefreshStrategy.LAZY
+            ) as connector:
                 conn: asyncpg.Connection = await connector.connect(
                     # Alloydb instance connection name
                     f"projects/{config.project}/locations/{config.region}/clusters/{config.cluster}/instances/{config.instance}",

--- a/retrieval_service/datastore/providers/cloudsql_mysql.py
+++ b/retrieval_service/datastore/providers/cloudsql_mysql.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from typing import Any, Literal, Optional
 
 import pymysql
-from google.cloud.sql.connector import Connector
+from google.cloud.sql.connector import Connector, RefreshStrategy
 from pydantic import BaseModel
 from sqlalchemy import Engine, create_engine, text
 from sqlalchemy.engine.base import Engine
@@ -54,7 +54,7 @@ class Client(datastore.Client[Config]):
     @classmethod
     def create_sync(cls, config: Config) -> "Client":
         def getconn() -> pymysql.Connection:
-            with Connector() as connector:
+            with Connector(refresh_strategy=RefreshStrategy.LAZY) as connector:
                 conn: pymysql.Connection = connector.connect(
                     # Cloud SQL instance connection name
                     f"{config.project}:{config.region}:{config.instance}",

--- a/retrieval_service/datastore/providers/cloudsql_postgres.py
+++ b/retrieval_service/datastore/providers/cloudsql_postgres.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from typing import Any, Literal, Optional
 
 import asyncpg
-from google.cloud.sql.connector import Connector
+from google.cloud.sql.connector import Connector, RefreshStrategy
 from pgvector.asyncpg import register_vector
 from pydantic import BaseModel
 from sqlalchemy import text
@@ -55,7 +55,9 @@ class Client(datastore.Client[Config]):
         loop = asyncio.get_running_loop()
 
         async def getconn() -> asyncpg.Connection:
-            async with Connector(loop=loop) as connector:
+            async with Connector(
+                loop=loop, refresh_strategy=RefreshStrategy.LAZY
+            ) as connector:
                 conn: asyncpg.Connection = await connector.connect_async(
                     # Cloud SQL instance connection name
                     f"{config.project}:{config.region}:{config.instance}",

--- a/retrieval_service/requirements.txt
+++ b/retrieval_service/requirements.txt
@@ -8,8 +8,8 @@ langchain-core==0.2.8
 pgvector==0.2.5
 pydantic==2.6.1
 uvicorn[standard]==0.27.0.post1
-cloud-sql-python-connector==1.6.0
-google-cloud-alloydb-connector[asyncpg]==1.1.1
+cloud-sql-python-connector==1.10.0
+google-cloud-alloydb-connector[asyncpg]==1.2.0
 sqlalchemy==2.0.25
 pandas==2.2.2
 pandas-stubs==2.2.2.240603


### PR DESCRIPTION
The Cloud SQL Python Connector just released a new version `v1.10.0`,
same with AlloyDB Python Connector `v1.2.0` that support setting the
`refresh_strategy` argument of the connector.

Setting the refresh strategy to lazy refresh is recommended for
serverless environments. As the default refresh strategy is to
have background refreshes occur to get the instance metadata and a fresh
certificate to use for the SSL/TLS connection.

However, these background refreshes can be throttled when serverless
environments scale to zero (Cloud Functions, Cloud Run etc.).

This PR will fix the ambiguous errors that are a result of the CPU being
throttled for connectors.
