### PR TITLE
ci: update release please to do v0.1.0 instead of v1.0.0

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,3 +30,4 @@ jobs:
         uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4.1.3
         with:
           release-type: simple
+          bump-minor-pre-major: true


### PR DESCRIPTION
Release please default first version to v1.0.0.
Set bump-minor-pre-major field to Yes in order to set first version to v0.1.0. [reference](https://github.com/googleapis/release-please/issues/558)