### PR TITLE
chore: implement langgraph

### DIFF
--- a/llm_demo/orchestrator/langgraph/react_graph.py
+++ b/llm_demo/orchestrator/langgraph/react_graph.py
@@ -1,0 +1,140 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from typing import Annotated, Literal, Sequence, TypedDict
+
+from aiohttp import ClientSession
+from langchain_core.messages import AIMessage, BaseMessage, ToolCall
+from langchain_core.prompts.chat import ChatPromptTemplate
+from langchain_core.runnables import RunnableConfig, RunnableLambda
+from langchain_google_vertexai import VertexAI
+from langgraph.checkpoint import MemorySaver
+from langgraph.graph import END, StateGraph
+from langgraph.graph.message import add_messages
+from langgraph.managed import IsLastStep
+
+from .tool_node import ToolNode
+
+
+class UserState(TypedDict):
+    """
+    State with messages and ClientSession for each session/user.
+    """
+
+    messages: Annotated[Sequence[BaseMessage], add_messages]
+    user_id_token: str
+    is_last_step: IsLastStep
+
+
+async def create_graph(
+    tools,
+    checkpointer: MemorySaver,
+    prompt: ChatPromptTemplate,
+    model_name: str,
+    debug: bool,
+):
+    """
+    Creates a graph that works with a chat model that utilizes tool calling.
+
+    Args:
+        tools: A list of StructuredTools that will bind with the chat model.
+        checkpointer: The checkpoint saver object. This is useful for persisting
+            the state of the graph (e.g., as chat memory).
+        prompt: Initial prompt for the model. This applies to messages before they
+            are passed into the LLM.
+        model_name: The chat model name.
+
+    Returns:
+        A compilled LangChain runnable that can be used for chat interactions.
+
+    The resulting graph looks like this:
+        [*] --> Start
+        Start --> Agent
+        Agent --> Tools : continue
+        Tools --> Agent
+        Agent --> End : end
+        End --> [*]
+    """
+    # tool node
+    tool_node = ToolNode(tools)
+
+    # model node
+    model = VertexAI(max_output_tokens=512, model_name=model_name, temperature=0.0)
+
+    # Add the prompt to the model to create a model runnable
+    model_runnable = prompt | model
+
+    async def acall_model(state: UserState, config: RunnableConfig):
+        """
+        The async function that calls the model
+        """
+        messages = state["messages"]
+        res = await model_runnable.ainvoke({"messages": messages}, config)
+        response = res.replace("```json", "").replace("```", "")
+        try:
+            json_response = json.loads(response)
+            action = json_response.get("action")
+            action_input = json_response.get("action_input")
+            if action == "Final Answer":
+                new_message = AIMessage(content=action_input)
+            else:
+                new_message = AIMessage(
+                    content="suggesting a tool call",
+                    tool_calls=[ToolCall(id="1", name=action, args=action_input)],
+                )
+        except Exception as e:
+            json_response = response
+            new_message = AIMessage(
+                content="Sorry, failed to generate the right format for response"
+            )
+        if state["is_last_step"] and hasattr(new_message, "tool_calls"):
+            return {
+                "messages": [
+                    AIMessage(
+                        content="Sorry, need more steps to process this request.",
+                    )
+                ]
+            }
+        return {"messages": [new_message]}
+
+    def agent_should_continue(state: UserState) -> Literal["continue", "end"]:
+        """
+        Function to determine which node is called next
+        """
+        messages = state["messages"]
+        last_message = messages[-1]
+        # If the LLM makes a tool call, then we route to the "tools" node
+        if hasattr(last_message, "tool_calls") and len(last_message.tool_calls) > 0:
+            return "continue"
+        # Otherwise, we stop (reply to the user)
+        return "end"
+
+    # Define a new graph
+    llm_graph = StateGraph(UserState)
+    llm_graph.add_node("agent", RunnableLambda(acall_model))
+    llm_graph.add_node("tools", tool_node)
+
+    # Set agent node as the first node to call
+    llm_graph.set_entry_point("agent")
+
+    # Add edges
+    llm_graph.add_conditional_edges(
+        "agent", agent_should_continue, {"continue": "tools", "end": END}
+    )
+    llm_graph.add_edge("tools", "agent")
+
+    # Compile graph into a LangChain Runnable
+    langgraph_app = llm_graph.compile(checkpointer=checkpointer, debug=debug)
+    return langgraph_app

--- a/llm_demo/orchestrator/langgraph/tool_node.py
+++ b/llm_demo/orchestrator/langgraph/tool_node.py
@@ -1,0 +1,119 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import copy
+import json
+from itertools import repeat
+from typing import Any, Callable, Dict, Optional, Sequence, Union
+
+from langchain_core.messages import AIMessage, AnyMessage, ToolCall, ToolMessage
+from langchain_core.runnables import RunnableConfig
+from langchain_core.runnables.config import get_executor_for_config
+from langchain_core.tools import BaseTool
+from langchain_core.tools import tool as create_tool
+from langgraph.utils import RunnableCallable
+
+
+def str_output(output: Any) -> str:
+    if isinstance(output, str):
+        return output
+    else:
+        try:
+            return json.dumps(output)
+        except Exception:
+            return str(output)
+
+
+class ToolNode(RunnableCallable):
+    """
+    A node that runs the tools requested in the last AIMessage. It can be used
+    either in StateGraph with a "messages" key or in MessageGraph. If multiple
+    tool calls are requested, they will be run in parallel. The output will be
+    a list of ToolMessages, one for each tool call.
+    """
+
+    def __init__(
+        self,
+        tools: Sequence[Union[BaseTool, Callable]],
+        *,
+        name: str = "tools",
+        tags: Optional[list[str]] = None,
+    ) -> None:
+        super().__init__(self._func, self._afunc, name=name, tags=tags, trace=False)
+        self.tools_by_name: Dict[str, BaseTool] = {}
+        for tool_ in tools:
+            if not isinstance(tool_, BaseTool):
+                tool_ = create_tool(tool_)
+            else:
+                base_tool_ = tool_
+            if hasattr(tool_, "name"):
+                self.tools_by_name[tool_.name] = base_tool_
+
+    def _func(self, input: dict[str, Any], config: RunnableConfig) -> Any:
+        if messages := input.get("messages", []):
+            output_type = "dict"
+            message = messages[-1]
+        else:
+            raise ValueError("No message found in input")
+
+        if not isinstance(message, AIMessage):
+            raise ValueError("Last message is not an AIMessage")
+
+        user_id_token = input.get("user_id_token")
+
+        def run_one(call: ToolCall, user_id_token: Optional[str]):
+            args = copy.copy(call["args"]) or {}
+            args["user_id_token"] = user_id_token
+            output = self.tools_by_name[call["name"]].invoke(args, config)
+            return ToolMessage(
+                content=str_output(output), name=call["name"], tool_call_id=call["id"]
+            )
+
+        with get_executor_for_config(config) as executor:
+            outputs = [
+                *executor.map(run_one, message.tool_calls, repeat(user_id_token))
+            ]
+            if output_type == "list":
+                return outputs
+            else:
+                return {"messages": outputs}
+
+    async def _afunc(self, input: dict[str, Any], config: RunnableConfig) -> Any:
+        if messages := input.get("messages", []):
+            output_type = "dict"
+            message = messages[-1]
+        else:
+            raise ValueError("No message found in input")
+
+        if not isinstance(message, AIMessage):
+            raise ValueError("Last message is not an AIMessage")
+
+        user_id_token = input.get("user_id_token")
+
+        async def run_one(call: ToolCall, user_id_token: Optional[str]):
+            args = copy.copy(call["args"]) or {}
+            args["user_id_token"] = user_id_token
+            output = await self.tools_by_name[call["name"]].ainvoke(args, config)
+            return ToolMessage(
+                content=str_output(output), name=call["name"], tool_call_id=call["id"]
+            )
+
+        outputs = await asyncio.gather(
+            *(run_one(call, user_id_token) for call in message.tool_calls)
+        )
+        if output_type == "list":
+            return outputs
+        else:
+            return {"messages": outputs}

--- a/llm_demo/requirements.txt
+++ b/llm_demo/requirements.txt
@@ -12,3 +12,4 @@ uvicorn[standard]==0.27.0.post1
 python-multipart==0.0.7
 pytz==2024.1
 types-pytz==2024.1.0.20240417
+langgraph==0.1.5


### PR DESCRIPTION
Update implementation to langgraph.

Main changes:
- We create a `UserAgent` for each session in langchain orchestration. For langgraph, we create a single graph and use `config` with `thread_id` to keep track of session. 

This PR does not include the following:
- human-in-the-loop workflow (e.g. book ticket confirmation from user).
- initialize tools with user-specific client. Currently the tools is initialized with a single client (each session/user is supposed to have their own client). Will create a custom ToolNode in another PR so that the Tool is able to get user's `client` object from the state.