### PR TITLE
chore: add cloudbuild and run_evaluation file

### DIFF
--- a/llm_demo/evaluation.cloudbuild.yaml
+++ b/llm_demo/evaluation.cloudbuild.yaml
@@ -1,0 +1,25 @@
+# Copyright 2024 Google LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - id: Install dependencies
+    name: python:3.11
+    dir: llm_demo 
+    script: pip install -r requirements.txt -r requirements-test.txt --user
+
+  - id: "Run evaluation service"
+    name: python:3.11
+    dir: llm_demo
+    script: |
+        #!/usr/bin/env bash
+        python run_evaluation.py

--- a/llm_demo/evaluation/evaluation.py
+++ b/llm_demo/evaluation/evaluation.py
@@ -39,6 +39,9 @@ async def run_llm_for_eval(
         except Exception as e:
             print(f"error invoking agent: {e}")
         else:
+            eval_data.instruction = (
+                INSTRUCTION + f"\nUser query is '{eval_data.query}'."
+            )
             eval_data.prediction_output = query_response.get("output")
 
             # Retrieve prediction_tool_calls from query response
@@ -120,7 +123,9 @@ def evaluate_response_phase(eval_datas: List[EvalData]) -> evaluation_base.EvalR
     responses = []
 
     for e in eval_datas:
-        instructions.append(e.instruction or "answer user query based on context given")
+        instructions.append(
+            e.instruction or "answer user query based on context given."
+        )
         context_str = (
             [json.dumps(c) for c in e.context] if e.context else ["no data retrieved"]
         )
@@ -140,3 +145,23 @@ def evaluate_response_phase(eval_datas: List[EvalData]) -> evaluation_base.EvalR
         experiment=RESPONSE_EXPERIMENT_NAME,
     ).evaluate()
     return eval_result
+
+
+INSTRUCTION = """The Cymbal Air Customer Service Assistant helps customers of Cymbal Air with their travel needs.
+
+Cymbal Air (airline unique two letter identifier as CY) is a passenger airline offering convenient flights to many cities around the world from its
+hub in San Francisco. Cymbal Air takes pride in using the latest technology to offer the best customer
+service!
+
+Cymbal Air Customer Service Assistant (or just "Assistant" for short) is designed to assist
+with a wide range of tasks, from answering simple questions to complex multi-query questions that
+require passing results from one query to another. Using the latest AI models, Assistant is able to
+generate human-like text based on the input it receives, allowing it to engage in natural-sounding
+conversations and provide responses that are coherent and relevant to the topic at hand. The assistant should 
+not answer questions about other peoples information for privacy reasons. 
+
+Assistant is a powerful tool that can help answer a wide range of questions pertaining to travel on Cymbal Air
+as well as ammenities of San Francisco Airport.
+
+Answer user query based on context or information given.
+"""

--- a/llm_demo/requirements.txt
+++ b/llm_demo/requirements.txt
@@ -1,5 +1,5 @@
 fastapi==0.109.2
-google-cloud-aiplatform==1.59.0
+google-cloud-aiplatform[rapid_evaluation]==1.59.0
 google-auth==2.32.0
 itsdangerous==2.2.0
 jinja2==3.1.4
@@ -13,3 +13,4 @@ python-multipart==0.0.7
 pytz==2024.1
 types-pytz==2024.1.0.20240417
 pandas-stubs==2.2.2.240603
+pandas==2.1.4

--- a/llm_demo/run_evaluation.py
+++ b/llm_demo/run_evaluation.py
@@ -1,0 +1,61 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import os
+import uuid
+
+import pandas as pd
+
+from evaluation import (
+    evaluate_response_phase,
+    evaluate_retrieval_phase,
+    goldens,
+    run_llm_for_eval,
+)
+from orchestrator import createOrchestrator
+
+
+def export_metrics_table_csv(retrieval: pd.DataFrame, response: pd.DataFrame):
+    """
+    Export detailed metrics table to csv file
+    """
+    retrieval.to_csv("retrieval_eval.csv")
+    response.to_csv("response_eval.csv")
+
+
+async def main():
+    EXPORT_CSV = bool(os.getenv("EXPORT_CSV", default=False))
+
+    # Prepare orchestrator and session
+    orc = createOrchestrator("langchain-tools")
+    session_id = str(uuid.uuid4())
+    session = {"uuid": session_id}
+    await orc.user_session_create(session)
+
+    # Run evaluation
+    eval_lists = await run_llm_for_eval(goldens, orc, session, session_id)
+    retrieval_eval_results = evaluate_retrieval_phase(eval_lists)
+    response_eval_results = evaluate_response_phase(eval_lists)
+    print(f"Retrieval phase eval results: {retrieval_eval_results.summary_metrics}")
+    print(f"Response phase eval results: {response_eval_results.summary_metrics}")
+
+    if EXPORT_CSV:
+        export_metrics_table_csv(
+            retrieval_eval_results.metrics_table, response_eval_results.metrics_table
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Add run_evaluation.py file and automatic cloudbuild trigger during PR.

Cloudbuild trigger will automatically run the evaluation and the results will be added to GCP under vertexai/experiments.

Detailed metric table (with row specific metrics) could be obtain by running locally with `export EXPORT_CSV=True`.