### PR TITLE
feat: Add category label nodes and BELONGS_TO relationships

### DIFF
--- a/retrieval_service/datastore/providers/neo4j_graph.py
+++ b/retrieval_service/datastore/providers/neo4j_graph.py
@@ -86,6 +86,7 @@ class Client(datastore.Client[Config]):
                 )
 
                 # Create Category node
+                # MERGE prevents duplicate nodes by first checking if they already exist
                 await tx.run(
                     """
                     MERGE (c:Category {name: $category})
@@ -94,6 +95,7 @@ class Client(datastore.Client[Config]):
                 )
 
                 # Create BELONGS_TO relationship
+                # MERGE prevents duplicate relationships by first checking if they already exist
                 await tx.run(
                     """
                     MATCH (a:Amenity {id: $id}), (c:Category {name: $category})

--- a/retrieval_service/datastore/providers/neo4j_graph.py
+++ b/retrieval_service/datastore/providers/neo4j_graph.py
@@ -70,6 +70,8 @@ class Client(datastore.Client[Config]):
 
         async def create_amenities(tx, amenities):
             for amenity in amenities:
+
+                # Create Amenity node
                 await tx.run(
                     """
                     CREATE (a:Amenity {id: $id, name: $name, description: $description, location: $location, terminal: $terminal, category: $category, hour: $hour})
@@ -81,6 +83,24 @@ class Client(datastore.Client[Config]):
                     terminal=amenity.terminal,
                     category=amenity.category,
                     hour=amenity.hour,
+                )
+
+                # Create Category node
+                await tx.run(
+                    """
+                    MERGE (c:Category {name: $category})
+                    """,
+                    category=amenity.category,
+                )
+
+                # Create BELONGS_TO relationship
+                await tx.run(
+                    """
+                    MATCH (a:Amenity {id: $id}), (c:Category {name: $category})
+                    MERGE (a)-[:BELONGS_TO]->(c)
+                    """,
+                    id=amenity.id,
+                    category=amenity.category,
                 )
 
         async with self.__driver.session() as session:

--- a/retrieval_service/datastore/providers/neo4j_graph_test.py
+++ b/retrieval_service/datastore/providers/neo4j_graph_test.py
@@ -79,6 +79,9 @@ async def ds(
     await ds.close()
 
 
+# Test nodes
+
+
 async def test_total_amenity_nodes_count(ds: neo4j_graph.Client):
     async with ds.driver.session() as session:
         result = await session.run("MATCH (a: Amenity) RETURN count(a) AS count")
@@ -92,7 +95,7 @@ async def test_total_amenity_nodes_count(ds: neo4j_graph.Client):
     ), f"Expected {expected_count} nodes, but found {count}"
 
 
-async def get_amenity_id(ds: neo4j_graph.Client):
+async def test_get_amenity_id(ds: neo4j_graph.Client):
     amenity = await ds.get_amenity(35)
 
     assert amenity, f"No amenity found with id 35"
@@ -123,3 +126,34 @@ async def get_amenity_id(ds: neo4j_graph.Client):
     )
 
     assert amenity == expected_amenity
+
+
+async def test_total_category_nodes_count(ds: neo4j_graph.Client):
+    async with ds.driver.session() as session:
+        result = await session.run("MATCH (c: Category) RETURN count(c) AS count")
+        record = await result.single()
+        count = record["count"]
+        print(count)
+
+    expected_count = 3
+    assert (
+        count == expected_count
+    ), f"Expected {expected_count} nodes, but found {count}"
+
+
+# Test relationships
+
+
+async def test_total_belongs_to_relationships_count(ds: neo4j_graph.Client):
+    async with ds.driver.session() as session:
+        result = await session.run(
+            "MATCH ()-[r:BELONGS_TO]->() RETURN count(r) AS count"
+        )
+        record = await result.single()
+        count = record["count"]
+        print(count)
+
+    expected_count = 127
+    assert (
+        count == expected_count
+    ), f"Expected {expected_count} BELONGS_TO relationships, but found {count}"


### PR DESCRIPTION
Add `category` label nodes to the current graph, and connect already existing `amenities` label nodes to them through `BELONGS_TO` relationship. 

Add test cases to:
- Guarantee the successful creation of `category` nodes based on the categories found on the current `amenity_dataset.csv` 
- Guarantee the successful creation of `BELONGS_TO` relationships, one per amenity node based on their category field on the current `amenity_dataset.csv`