### PR TITLE
feat: Remove user ID and user email from `list_tickets()` result

### DIFF
--- a/retrieval_service/datastore/datastore.py
+++ b/retrieval_service/datastore/datastore.py
@@ -249,7 +249,7 @@ class Client(ABC, Generic[C]):
     async def list_tickets(
         self,
         user_id: str,
-    ) -> list[str]:
+    ) -> list[Any]:
         raise NotImplementedError("Subclass should implement this!")
 
     @abstractmethod

--- a/retrieval_service/datastore/datastore.py
+++ b/retrieval_service/datastore/datastore.py
@@ -249,7 +249,7 @@ class Client(ABC, Generic[C]):
     async def list_tickets(
         self,
         user_id: str,
-    ) -> list[models.Ticket]:
+    ) -> list[str]:
         raise NotImplementedError("Subclass should implement this!")
 
     @abstractmethod

--- a/retrieval_service/datastore/providers/alloydb.py
+++ b/retrieval_service/datastore/providers/alloydb.py
@@ -576,12 +576,12 @@ class Client(datastore.Client[Config]):
     async def list_tickets(
         self,
         user_id: str,
-    ) -> list[models.Ticket]:
+    ) -> list[Any]:
         async with self.__pool.connect() as conn:
             s = text(
                 """
-                    SELECT * FROM tickets
-                    WHERE user_id = :user_id
+                SELECT user_name, airline, flight_number, departure_airport, arrival_airport, departure_time, arrival_time FROM tickets
+                WHERE user_id = :user_id
                 """
             )
             params = {
@@ -589,7 +589,7 @@ class Client(datastore.Client[Config]):
             }
             results = (await conn.execute(s, params)).mappings().fetchall()
 
-        res = [models.Ticket.model_validate(r) for r in results]
+        res = [r for r in results]
         return res
 
     async def policies_search(

--- a/retrieval_service/datastore/providers/cloudsql_mysql.py
+++ b/retrieval_service/datastore/providers/cloudsql_mysql.py
@@ -767,7 +767,7 @@ class Client(datastore.Client[Config]):
         with self.__pool.connect() as conn:
             s = text(
                 """
-                SELECT * FROM tickets
+                SELECT user_name, airline, flight_number, departure_airport, arrival_airport, departure_time, arrival_time FROM tickets
                 WHERE user_id = :user_id
                 """
             )
@@ -777,7 +777,7 @@ class Client(datastore.Client[Config]):
 
             results = (conn.execute(s, parameters=params)).mappings().fetchall()
 
-        res = [models.Ticket.model_validate(r) for r in results]
+        res = [r for r in results]
         return res
 
     async def list_tickets(

--- a/retrieval_service/datastore/providers/cloudsql_mysql.py
+++ b/retrieval_service/datastore/providers/cloudsql_mysql.py
@@ -763,7 +763,7 @@ class Client(datastore.Client[Config]):
     def list_tickets_sync(
         self,
         user_id: str,
-    ) -> list[models.Ticket]:
+    ) -> list[Any]:
         with self.__pool.connect() as conn:
             s = text(
                 """

--- a/retrieval_service/datastore/providers/cloudsql_mysql_test.py
+++ b/retrieval_service/datastore/providers/cloudsql_mysql_test.py
@@ -627,18 +627,23 @@ async def test_insert_ticket(ds: cloudsql_mysql.Client):
 
 async def test_list_tickets(ds: cloudsql_mysql.Client):
     res = await ds.list_tickets("1")
-    expected = models.Ticket(
-        user_id=1,
-        user_name="test",
-        user_email="test",
-        airline="UA",
-        flight_number="1532",
-        departure_airport="SFO",
-        arrival_airport="DEN",
-        departure_time=datetime.strptime("2024-01-01 05:50:00", "%Y-%m-%d %H:%M:%S"),
-        arrival_time=datetime.strptime("2024-01-01 09:23:00", "%Y-%m-%d %H:%M:%S"),
-    )
-    assert res == [expected]
+    expected = [
+        {
+            "user_name": "test",
+            "airline": "UA",
+            "flight_number": "1532",
+            "departure_airport": "SFO",
+            "arrival_airport": "DEN",
+            "departure_time": datetime.strptime(
+                "2024-01-01 05:50:00", "%Y-%m-%d %H:%M:%S"
+            ),
+            "arrival_time": datetime.strptime(
+                "2024-01-01 09:23:00", "%Y-%m-%d %H:%M:%S"
+            ),
+        }
+    ]
+
+    assert res == expected
 
 
 async def test_validate_ticket(ds: cloudsql_mysql.Client):

--- a/retrieval_service/datastore/providers/cloudsql_postgres.py
+++ b/retrieval_service/datastore/providers/cloudsql_postgres.py
@@ -576,7 +576,7 @@ class Client(datastore.Client[Config]):
     async def list_tickets(
         self,
         user_id: str,
-    ) -> list[models.Ticket]:
+    ) -> list[Any]:
         async with self.__pool.connect() as conn:
             s = text(
                 """

--- a/retrieval_service/datastore/providers/cloudsql_postgres.py
+++ b/retrieval_service/datastore/providers/cloudsql_postgres.py
@@ -580,8 +580,8 @@ class Client(datastore.Client[Config]):
         async with self.__pool.connect() as conn:
             s = text(
                 """
-                    SELECT * FROM tickets
-                    WHERE user_id = :user_id
+                SELECT user_name, airline, flight_number, departure_airport, arrival_airport, departure_time, arrival_time FROM tickets
+                WHERE user_id = :user_id
                 """
             )
             params = {
@@ -589,7 +589,7 @@ class Client(datastore.Client[Config]):
             }
             results = (await conn.execute(s, params)).mappings().fetchall()
 
-        res = [models.Ticket.model_validate(r) for r in results]
+        res = [r for r in results]
         return res
 
     async def policies_search(

--- a/retrieval_service/datastore/providers/cloudsql_postgres_test.py
+++ b/retrieval_service/datastore/providers/cloudsql_postgres_test.py
@@ -614,18 +614,23 @@ async def test_insert_ticket(ds: cloudsql_postgres.Client):
 
 async def test_list_tickets(ds: cloudsql_postgres.Client):
     res = await ds.list_tickets("1")
-    expected = models.Ticket(
-        user_id=1,
-        user_name="test",
-        user_email="test",
-        airline="UA",
-        flight_number="1532",
-        departure_airport="SFO",
-        arrival_airport="DEN",
-        departure_time=datetime.strptime("2024-01-01 05:50:00", "%Y-%m-%d %H:%M:%S"),
-        arrival_time=datetime.strptime("2024-01-01 09:23:00", "%Y-%m-%d %H:%M:%S"),
-    )
-    assert res == [expected]
+    expected = [
+        {
+            "user_name": "test",
+            "airline": "UA",
+            "flight_number": "1532",
+            "departure_airport": "SFO",
+            "arrival_airport": "DEN",
+            "departure_time": datetime.strptime(
+                "2024-01-01 05:50:00", "%Y-%m-%d %H:%M:%S"
+            ),
+            "arrival_time": datetime.strptime(
+                "2024-01-01 09:23:00", "%Y-%m-%d %H:%M:%S"
+            ),
+        }
+    ]
+
+    assert res == expected
 
 
 async def test_validate_ticket(ds: cloudsql_postgres.Client):

--- a/retrieval_service/datastore/providers/firestore.py
+++ b/retrieval_service/datastore/providers/firestore.py
@@ -509,7 +509,7 @@ class Client(datastore.Client[Config]):
     async def list_tickets(
         self,
         user_id: str,
-    ) -> list[models.Ticket]:
+    ) -> list[Any]:
         raise NotImplementedError("Not Implemented")
 
     async def policies_search(

--- a/retrieval_service/datastore/providers/neo4j_graph.py
+++ b/retrieval_service/datastore/providers/neo4j_graph.py
@@ -16,7 +16,6 @@ import asyncio
 import csv
 from typing import Any, Literal, Optional
 
-
 from neo4j import AsyncDriver, AsyncGraphDatabase
 from pydantic import BaseModel
 

--- a/retrieval_service/datastore/providers/neo4j_graph.py
+++ b/retrieval_service/datastore/providers/neo4j_graph.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import asyncio
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
 from neo4j import AsyncDriver, AsyncGraphDatabase
 from pydantic import BaseModel
@@ -170,7 +170,7 @@ class Client(datastore.Client[Config]):
     ):
         raise NotImplementedError("This client does not support tickets.")
 
-    async def list_tickets(self, user_id: str) -> list[models.Ticket]:
+    async def list_tickets(self, user_id: str) -> list[Any]:
         raise NotImplementedError("This client does not support tickets.")
 
     async def policies_search(

--- a/retrieval_service/datastore/providers/postgres.py
+++ b/retrieval_service/datastore/providers/postgres.py
@@ -495,16 +495,16 @@ class Client(datastore.Client[Config]):
     async def list_tickets(
         self,
         user_id: str,
-    ) -> list[models.Ticket]:
+    ) -> list[Any]:
         results = await self.__pool.fetch(
             """
-                SELECT * FROM tickets
-                WHERE user_id = $1
+            SELECT user_name, airline, flight_number, departure_airport, arrival_airport, departure_time, arrival_time FROM tickets
+            WHERE user_id = $1
             """,
             user_id,
             timeout=10,
         )
-        results = [models.Ticket.model_validate(dict(r)) for r in results]
+        results = [r for r in results]
         return results
 
     async def policies_search(

--- a/retrieval_service/datastore/providers/spanner_gsql.py
+++ b/retrieval_service/datastore/providers/spanner_gsql.py
@@ -675,7 +675,6 @@ class Client(datastore.Client[Config]):
                 },
             )
 
-        # Convert query result to model instance using model_validate method
         amenities = [
             {key: value for key, value in zip(self.AMENITIES_COLUMNS[1:], a)}
             for a in results
@@ -932,7 +931,7 @@ class Client(datastore.Client[Config]):
             # Spread SQL query for readability
             results = snapshot.execute_sql(
                 sql="""
-                SELECT * FROM tickets
+                SELECT user_name, airline, flight_number, departure_airport, arrival_airport, departure_time, arrival_time FROM tickets
                 WHERE user_id = @user_id
                 """,
                 params={"user_id": user_id},
@@ -940,28 +939,7 @@ class Client(datastore.Client[Config]):
             )
 
         # Convert query results to model instances using model_validate method
-        tickets = [
-            models.Ticket.model_validate(
-                {
-                    key: value
-                    for key, value in zip(
-                        [
-                            "user_id",
-                            "user_name",
-                            "user_email",
-                            "airline",
-                            "flight_number",
-                            "departure_airport",
-                            "arrival_airport",
-                            "departure_time",
-                            "arrival_time",
-                        ],
-                        a,
-                    )
-                }
-            )
-            for a in results
-        ]
+        tickets = [r for r in results]
 
         return tickets
 

--- a/retrieval_service/datastore/providers/spanner_gsql.py
+++ b/retrieval_service/datastore/providers/spanner_gsql.py
@@ -920,7 +920,7 @@ class Client(datastore.Client[Config]):
     async def list_tickets(
         self,
         user_id: str,
-    ) -> list[models.Ticket]:
+    ) -> list[Any]:
         """
         Retrieves a list of tickets for a user.
 


### PR DESCRIPTION
Exposing user ID and email to LLM is unnecessary and we should remove them from `list_tickets()` results for increased security.

1. Modify queries to return only necessary columns.
2. Remove `Ticket` model validation when returning results from tickets endpoints.