### PR TITLE
feat: Add similar_to relationship from csv ingestion

### DIFF
--- a/data/relationships/amenity_relationships.csv
+++ b/data/relationships/amenity_relationships.csv
@@ -1,0 +1,202 @@
+src_id,rel_type,tgt_id
+Coffee shop 732,Similar_to,Fast food 241
+Coffee shop 732,Similar_to,Coffee shop 829
+Coffee shop 732,Similar_to,Hawaii coffee store
+Coffee shop 829,Similar_to,Fast food 241
+Coffee shop 829,Similar_to,Coffee shop 732
+Hawaii coffee store,Similar_to,Coffee shop 732
+Hawaii coffee store,Similar_to,Coffee shop 829
+Electronics store 145,Similar_to,Electronics store 642
+Electronics store 145,Similar_to,Electronics store 520
+Electronics store 642,Similar_to,Electronics store 145
+Electronics store 642,Similar_to,Electronics store 520
+Electronics store 520,Similar_to,Electronics store 145
+Electronics store 520,Similar_to,Electronics store 642
+Clothing store 487,Similar_to,Shop 971
+Clothing store 487,Similar_to,Clothing store 193
+Shop 971,Similar_to,Clothing store 487
+Shop 971,Similar_to,Clothing store 193
+Clothing store 193,Similar_to,Clothing store 487
+Clothing store 193,Similar_to,Shop 971
+Bar & grill 916,Similar_to,Fast food 714
+Bar & grill 916,Similar_to,Pei wei asian diner
+Fast food 714,Similar_to,Bar & grill 916
+Pei wei asian diner,Similar_to,Bar & grill 916
+Panda express,Similar_to,Fast food 714
+Sit-down restaurant 563,Similar_to,Sit-down restaurant 458
+Sit-down restaurant 563,Similar_to,Flight deck bar & grill
+Sit-down restaurant 458,Similar_to,Sit-down restaurant 563
+Flight deck bar & grill,Similar_to,Sit-down restaurant 563
+Starbucks coffee,Similar_to,Peet's coffee & tea
+Starbucks coffee,Similar_to,Coffee shop 732
+Peet's coffee & tea,Similar_to,Starbucks coffee
+Coffee shop 732,Similar_to,Starbucks coffee
+Travel essentials store 352,Similar_to,Travel essentials store 265
+Travel essentials store 352,Similar_to,Travelmart
+Travel essentials store 265,Similar_to,Travel essentials store 352
+Travelmart,Similar_to,Travel essentials store 352
+Airport information desk,Similar_to,Information center
+Airport information desk,Similar_to,Information center
+Information center,Similar_to,Airport information desk
+Information center,Similar_to,Airport information desk
+Travelex atm,Similar_to,Bank of america atm
+Travelex currency exchange,Similar_to,Currency exchange
+Currency exchange,Similar_to,Travelex currency exchange
+Currency exchange,Similar_to,Currency exchange kiosk
+Currency exchange kiosk,Similar_to,Currency exchange
+Gate gourmet deli,Similar_to,The deli counter
+Gate gourmet deli,Similar_to,Soup & salad station
+The deli counter,Similar_to,Gate gourmet deli
+The deli counter,Similar_to,Soup & salad station
+Soup & salad station,Similar_to,Gate gourmet deli
+Soup & salad station,Similar_to,The deli counter
+The local tap room,Similar_to,The spot
+The local tap room,Similar_to,The wine bar
+The spot,Similar_to,The local tap room
+The spot,Similar_to,The wine bar
+The wine bar,Similar_to,The local tap room
+The wine bar,Similar_to,The spot
+Freshii,Similar_to,Panera bread
+Freshii,Similar_to,Soup & salad station
+Panera bread,Similar_to,Freshii
+Panera bread,Similar_to,Soup & salad station
+Soup & salad station,Similar_to,Freshii
+Soup & salad station,Similar_to,Panera bread
+Sushi & sake bar,Similar_to,Pei wei asian diner
+Sushi & sake bar,Similar_to,Bar & grill 301
+Pei wei asian diner,Similar_to,Sushi & sake bar
+Bar & grill 301,Similar_to,Sushi & sake bar
+Yoga and meditation studio,Similar_to,Yoga studio store
+Yoga and meditation studio,Similar_to,Yoga & meditation room
+Yoga studio store,Similar_to,Yoga and meditation studio
+Yoga studio store,Similar_to,Yoga & meditation room
+Yoga & meditation room,Similar_to,Yoga and meditation studio
+Yoga & meditation room,Similar_to,Yoga studio store
+Children's book nook,Similar_to,Book passage
+Children's book nook,Similar_to,Bookworm books
+Book passage,Similar_to,Children's book nook
+Book passage,Similar_to,Bookworm books
+Bookworm books,Similar_to,Children's book nook
+Bookworm books,Similar_to,Book passage
+L'occitane en provence,Similar_to,Kiehl's
+L'occitane en provence,Similar_to,Mac cosmetics
+Kiehl's,Similar_to,L'occitane en provence
+Kiehl's,Similar_to,Mac cosmetics
+Mac cosmetics,Similar_to,L'occitane en provence
+Mac cosmetics,Similar_to,Kiehl's
+Dufry duty free,Similar_to,Gucci duty free
+Dufry duty free,Similar_to,Hermes duty free
+Gucci duty free,Similar_to,Dufry duty free
+Gucci duty free,Similar_to,Hermes duty free
+Hermes duty free,Similar_to,Dufry duty free
+Hermes duty free,Similar_to,Gucci duty free
+Tech gear,Similar_to,Brookstone
+Tech gear,Similar_to,Sunglass hut
+Brookstone,Similar_to,Tech gear
+Brookstone,Similar_to,Sunglass hut
+Sunglass hut,Similar_to,Tech gear
+Sunglass hut,Similar_to,Brookstone
+Travel plug adapters vending machine,Similar_to,Currency exchange kiosk
+Travel plug adapters vending machine,Similar_to,Atm
+Currency exchange kiosk,Similar_to,Travel plug adapters vending machine
+Atm,Similar_to,Travel plug adapters vending machine
+Mobile device charging station,Similar_to,Power charging stations
+Mobile device charging station,Similar_to,Laptop bar
+Power charging stations,Similar_to,Mobile device charging station
+Power charging stations,Similar_to,Laptop bar
+Laptop bar,Similar_to,Mobile device charging station
+Laptop bar,Similar_to,Power charging stations
+Public showers,Similar_to,Family restroom
+Public showers,Similar_to,Airport nursery
+Family restroom,Similar_to,Public showers
+Family restroom,Similar_to,Airport nursery
+Airport nursery,Similar_to,Public showers
+Airport nursery,Similar_to,Family restroom
+Minute suites,Similar_to,Sleep pods
+Minute suites,Similar_to,Airport limousine service
+Sleep pods,Similar_to,Minute suites
+Airport limousine service,Similar_to,Minute suites
+The executive lounge,Similar_to,The local tap room
+The executive lounge,Similar_to,The spot
+The local tap room,Similar_to,The executive lounge
+The spot,Similar_to,The executive lounge
+The wine cellar,Similar_to,The wine bar
+The wine cellar,Similar_to,The local tap room
+The wine bar,Similar_to,The wine cellar
+The local tap room,Similar_to,The wine cellar
+Xpress spa,Similar_to,Airport yoga studio
+Xpress spa,Similar_to,Hair salon
+Airport yoga studio,Similar_to,Xpress spa
+Hair salon,Similar_to,Xpress spa
+Travel essentials,Similar_to,Travelmart
+Travel essentials,Similar_to,Travel essentials store 352
+Travelmart,Similar_to,Travel essentials
+Travel essentials store 352,Similar_to,Travel essentials
+The market,Similar_to,Travel essentials store 265
+The market,Similar_to,Travel essentials
+Travel essentials store 265,Similar_to,The market
+Travel essentials,Similar_to,The market
+Art gallery,Similar_to,Children's book nook
+Art gallery,Similar_to,Book passage
+Children's book nook,Similar_to,Art gallery
+Book passage,Similar_to,Art gallery
+Play port arcade,Similar_to,Family restroom
+Play port arcade,Similar_to,Airport nursery
+Family restroom,Similar_to,Play port arcade
+Airport nursery,Similar_to,Play port arcade
+Golf simulator,Similar_to,Tech repair kiosk
+Golf simulator,Similar_to,Mobile device charging station
+Tech repair kiosk,Similar_to,Golf simulator
+Mobile device charging station,Similar_to,Golf simulator
+Dry cleaning & laundry service,Similar_to,Shoe shine service
+Dry cleaning & laundry service,Similar_to,Shoe valet
+Shoe shine service,Similar_to,Dry cleaning & laundry service
+Shoe valet,Similar_to,Dry cleaning & laundry service
+Shoe valet,Similar_to,Shoe shine service
+Shoe shine service,Similar_to,Shoe valet
+Newsbeat,Similar_to,News & gifts
+Newsbeat,Similar_to,Bookworm books
+News & gifts,Similar_to,Newsbeat
+News & gifts,Similar_to,Bookworm books
+Bookworm books,Similar_to,Newsbeat
+Bookworm books,Similar_to,News & gifts
+The hangar bar & grill,Similar_to,The spot
+The hangar bar & grill,Similar_to,The local tap room
+The spot,Similar_to,The hangar bar & grill
+The local tap room,Similar_to,The hangar bar & grill
+Johnnie walker lounge,Similar_to,The wine bar
+Johnnie walker lounge,Similar_to,The spot
+The wine bar,Similar_to,Johnnie walker lounge
+The spot,Similar_to,Johnnie walker lounge
+Meditation room,Similar_to,Yoga & meditation room
+Meditation room,Similar_to,Airport yoga studio
+Yoga & meditation room,Similar_to,Meditation room
+Airport yoga studio,Similar_to,Meditation room
+Pet relief area,Similar_to,Family restroom
+Pet relief area,Similar_to,Airport nursery
+Family restroom,Similar_to,Pet relief area
+Airport nursery,Similar_to,Pet relief area
+Luggage repair shop,Similar_to,Baggage storage
+Luggage repair shop,Similar_to,Luggage carts
+Baggage storage,Similar_to,Luggage repair shop
+Luggage carts,Similar_to,Luggage repair shop
+Luggage carts,Similar_to,Baggage storage
+Baggage storage,Similar_to,Luggage carts
+The reader's choice,Similar_to,Book passage
+The reader's choice,Similar_to,Bookworm books
+Book passage,Similar_to,The reader's choice
+Bookworm books,Similar_to,The reader's choice
+The market,Similar_to,Travel essentials store 265
+The market,Similar_to,Travel essentials
+Travel essentials store 265,Similar_to,The market
+Travel essentials,Similar_to,The market
+The wine cellar,Similar_to,The wine bar
+The wine cellar,Similar_to,The local tap room
+The wine bar,Similar_to,The wine cellar
+The local tap room,Similar_to,The wine cellar
+The executive lounge,Similar_to,The local tap room
+The executive lounge,Similar_to,The spot
+The local tap room,Similar_to,The executive lounge
+The spot,Similar_to,The executive lounge
+Panda express,Similar_to,Thai express
+Panda express,Similar_to,Pei wei asian diner

--- a/retrieval_service/datastore/providers/neo4j_graph.py
+++ b/retrieval_service/datastore/providers/neo4j_graph.py
@@ -74,7 +74,7 @@ class Client(datastore.Client[Config]):
                 # Create Amenity node
                 await tx.run(
                     """
-                    CREATE (a:Amenity {id: $id, name: $name, description: $description, location: $location, terminal: $terminal, category: $category, hour: $hour, embedding: $embedding})
+                    CREATE (a:Amenity {id: $id, name: $name, description: $description, location: $location, terminal: $terminal, category: $category, hour: $hour)
                     """,
                     id=amenity.id,
                     name=amenity.name,
@@ -83,7 +83,6 @@ class Client(datastore.Client[Config]):
                     terminal=amenity.terminal,
                     category=amenity.category,
                     hour=amenity.hour,
-                    embedding=amenity.embedding,
                 )
 
                 # Create Category node
@@ -170,24 +169,15 @@ class Client(datastore.Client[Config]):
     async def get_amenity(self, id: int) -> Optional[models.Amenity]:
         async with self.__driver.session() as session:
             result = await session.run(
-                """
-                MATCH (amenity: Amenity {id: $id})
-                RETURN amenity.id AS id, 
-                    amenity.name AS name, 
-                    amenity.description AS description, 
-                    amenity.location AS location, 
-                    amenity.terminal AS terminal, 
-                    amenity.category AS category, 
-                    amenity.hour AS hour
-                """,
-                id=id,
+                "MATCH (amenity: Amenity {id: $id}) RETURN amenity", id=id
             )
             record = await result.single()
 
             if not record:
                 return None
 
-            return models.Amenity(**record)
+            amenity_data = record["amenity"]
+            return models.Amenity(**amenity_data)
 
     async def amenities_search(
         self, query_embedding: list[float], similarity_threshold: float, top_k: int

--- a/retrieval_service/datastore/providers/neo4j_graph.py
+++ b/retrieval_service/datastore/providers/neo4j_graph.py
@@ -100,8 +100,7 @@ class Client(datastore.Client[Config]):
                 # MERGE prevents duplicate relationships by first checking if they already exist
                 await tx.run(
                     """
-                    MATCH (a:Amenity {id: $id})
-                    MATCH (c:Category {name: $category})
+                    MATCH (a:Amenity {id: $id}), MATCH (c:Category {name: $category})
                     MERGE (a)-[:BELONGS_TO]->(c)
                     """,
                     id=amenity.id,

--- a/retrieval_service/datastore/providers/neo4j_graph.py
+++ b/retrieval_service/datastore/providers/neo4j_graph.py
@@ -112,7 +112,7 @@ class Client(datastore.Client[Config]):
             csv_file_path = "../data/relationships/amenity_relationships.csv"
 
             with open(csv_file_path, "r") as file:
-                reader = csv.DictReader(file)
+                reader = csv.DictReader(file, delimiter=",")
                 for row in reader:
                     src_name = row["src_id"]
                     rel_type = row["rel_type"]
@@ -120,7 +120,7 @@ class Client(datastore.Client[Config]):
 
                     # Generate and run the Cypher query
                     # Case-insensitive and apostrophes-insensitive match
-                    result = await tx.run(
+                    await tx.run(
                         f"""
                         MATCH (a:Amenity) WHERE toLower(a.name) = toLower("{src_name}")
                         MATCH (b:Amenity) WHERE toLower(b.name) = toLower("{tgt_name}")

--- a/retrieval_service/datastore/providers/neo4j_graph.py
+++ b/retrieval_service/datastore/providers/neo4j_graph.py
@@ -100,7 +100,7 @@ class Client(datastore.Client[Config]):
                 # MERGE prevents duplicate relationships by first checking if they already exist
                 await tx.run(
                     """
-                    MATCH (a:Amenity {id: $id}), MATCH (c:Category {name: $category})
+                    MATCH (a:Amenity {id: $id}), (c:Category {name: $category})
                     MERGE (a)-[:BELONGS_TO]->(c)
                     """,
                     id=amenity.id,

--- a/retrieval_service/datastore/providers/neo4j_graph.py
+++ b/retrieval_service/datastore/providers/neo4j_graph.py
@@ -98,11 +98,10 @@ class Client(datastore.Client[Config]):
             for amenity in amenities:
                 # Create BELONGS_TO relationship
                 # MERGE prevents duplicate relationships by first checking if they already exist
-                # OPTIONAL avoids cartesian product
                 await tx.run(
                     """
                     MATCH (a:Amenity {id: $id})
-                    OPTIONAL MATCH (c:Category {name: $category})
+                    MATCH (c:Category {name: $category})
                     MERGE (a)-[:BELONGS_TO]->(c)
                     """,
                     id=amenity.id,
@@ -121,7 +120,7 @@ class Client(datastore.Client[Config]):
                     tgt_name = row["tgt_id"]
 
                     # Generate and run the Cypher query
-                    # Case-insensitive and apostrophes-insensitive
+                    # Case-insensitive and apostrophes-insensitive match
                     result = await tx.run(
                         f"""
                         MATCH (a:Amenity) WHERE toLower(a.name) = toLower("{src_name}")

--- a/retrieval_service/datastore/providers/neo4j_graph_test.py
+++ b/retrieval_service/datastore/providers/neo4j_graph_test.py
@@ -157,3 +157,20 @@ async def test_total_belongs_to_relationships_count(ds: neo4j_graph.Client):
     assert (
         count == expected_count
     ), f"Expected {expected_count} BELONGS_TO relationships, but found {count}"
+
+
+async def test_total_similar_to_relationships_count(ds: neo4j_graph.Client):
+    async with ds.driver.session() as session:
+        result = await session.run(
+            # Lower-case relationship naming due to graph generation output format
+            "MATCH ()-[r:Similar_to]->() RETURN count(r) AS count"
+        )
+        record = await result.single()
+        count = record["count"]
+        print(count)
+
+    # Bi-directional pairs are counted only once
+    expected_count = 217
+    assert (
+        count == expected_count
+    ), f"Expected {expected_count} BELONGS_TO relationships, but found {count}"


### PR DESCRIPTION
Add `SIMILAR_TO` relationship to the current amenity knowledge graph through csv file ingestion.

File has a format of source id from one node (src_id) , relationship type (rel_type) and target id to the other node (tgt_id).

Which then will be ingested by the `create_relationships` function to be processed as a Cypher query. 