### PR TITLE
feat: Consolidate postgres providers

### DIFF
--- a/retrieval_service/datastore/providers/alloydb.py
+++ b/retrieval_service/datastore/providers/alloydb.py
@@ -12,20 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
-from datetime import datetime
 from typing import Any, Literal, Optional
 
 import asyncpg
 from google.cloud.alloydb.connector import AsyncConnector, RefreshStrategy
 from pgvector.asyncpg import register_vector
 from pydantic import BaseModel
-from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 import models
 
 from .. import datastore
+from .postgres_datastore import PostgresDatastore
 
 ALLOYDB_PG_IDENTIFIER = "alloydb-postgres"
 
@@ -42,15 +40,15 @@ class Config(BaseModel, datastore.AbstractConfig):
 
 
 class Client(datastore.Client[Config]):
-    __pool: AsyncEngine
     __connector: Optional[AsyncConnector] = None
+    __pg_ds: PostgresDatastore
 
     @datastore.classproperty
     def kind(cls):
         return ALLOYDB_PG_IDENTIFIER
 
     def __init__(self, pool: AsyncEngine):
-        self.__pool = pool
+        self.__pg_ds = PostgresDatastore(pool)
 
     @classmethod
     async def create(cls, config: Config) -> "Client":
@@ -85,214 +83,9 @@ class Client(datastore.Client[Config]):
         flights: list[models.Flight],
         policies: list[models.Policy],
     ) -> None:
-        async with self.__pool.connect() as conn:
-            # If the table already exists, drop it to avoid conflicts
-            await conn.execute(text("DROP TABLE IF EXISTS airports CASCADE"))
-            # Create a new table
-            await conn.execute(
-                text(
-                    """
-                    CREATE TABLE airports(
-                      id INT PRIMARY KEY,
-                      iata TEXT,
-                      name TEXT,
-                      city TEXT,
-                      country TEXT
-                    )
-                    """
-                )
-            )
-            # Insert all the data
-            await conn.execute(
-                text(
-                    """INSERT INTO airports VALUES (:id, :iata, :name, :city, :country)"""
-                ),
-                [
-                    {
-                        "id": a.id,
-                        "iata": a.iata,
-                        "name": a.name,
-                        "city": a.city,
-                        "country": a.country,
-                    }
-                    for a in airports
-                ],
-            )
-
-            await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
-            # If the table already exists, drop it to avoid conflicts
-            await conn.execute(text("DROP TABLE IF EXISTS amenities CASCADE"))
-            # Create a new table
-            await conn.execute(
-                text(
-                    """
-                    CREATE TABLE amenities(
-                      id INT PRIMARY KEY,
-                      name TEXT,
-                      description TEXT,
-                      location TEXT,
-                      terminal TEXT,
-                      category TEXT,
-                      hour TEXT,
-                      sunday_start_hour TIME,
-                      sunday_end_hour TIME,
-                      monday_start_hour TIME,
-                      monday_end_hour TIME,
-                      tuesday_start_hour TIME,
-                      tuesday_end_hour TIME,
-                      wednesday_start_hour TIME,
-                      wednesday_end_hour TIME,
-                      thursday_start_hour TIME,
-                      thursday_end_hour TIME,
-                      friday_start_hour TIME,
-                      friday_end_hour TIME,
-                      saturday_start_hour TIME,
-                      saturday_end_hour TIME,
-                      content TEXT NOT NULL,
-                      embedding vector(768) NOT NULL
-                    )
-                    """
-                )
-            )
-            # Insert all the data
-            await conn.execute(
-                text(
-                    """
-                    INSERT INTO amenities VALUES (:id, :name, :description, :location,
-                      :terminal, :category, :hour, :sunday_start_hour, :sunday_end_hour,
-                      :monday_start_hour, :monday_end_hour, :tuesday_start_hour,
-                      :tuesday_end_hour, :wednesday_start_hour, :wednesday_end_hour,
-                      :thursday_start_hour, :thursday_end_hour, :friday_start_hour,
-                      :friday_end_hour, :saturday_start_hour, :saturday_end_hour, :content, :embedding)
-                    """
-                ),
-                [
-                    {
-                        "id": a.id,
-                        "name": a.name,
-                        "description": a.description,
-                        "location": a.location,
-                        "terminal": a.terminal,
-                        "category": a.category,
-                        "hour": a.hour,
-                        "sunday_start_hour": a.sunday_start_hour,
-                        "sunday_end_hour": a.sunday_end_hour,
-                        "monday_start_hour": a.monday_start_hour,
-                        "monday_end_hour": a.monday_end_hour,
-                        "tuesday_start_hour": a.tuesday_start_hour,
-                        "tuesday_end_hour": a.tuesday_end_hour,
-                        "wednesday_start_hour": a.wednesday_start_hour,
-                        "wednesday_end_hour": a.wednesday_end_hour,
-                        "thursday_start_hour": a.thursday_start_hour,
-                        "thursday_end_hour": a.thursday_end_hour,
-                        "friday_start_hour": a.friday_start_hour,
-                        "friday_end_hour": a.friday_end_hour,
-                        "saturday_start_hour": a.saturday_start_hour,
-                        "saturday_end_hour": a.saturday_end_hour,
-                        "content": a.content,
-                        "embedding": a.embedding,
-                    }
-                    for a in amenities
-                ],
-            )
-
-            # If the table already exists, drop it to avoid conflicts
-            await conn.execute(text("DROP TABLE IF EXISTS flights CASCADE"))
-            # Create a new table
-            await conn.execute(
-                text(
-                    """
-                    CREATE TABLE flights(
-                      id INTEGER PRIMARY KEY,
-                      airline TEXT,
-                      flight_number TEXT,
-                      departure_airport TEXT,
-                      arrival_airport TEXT,
-                      departure_time TIMESTAMP,
-                      arrival_time TIMESTAMP,
-                      departure_gate TEXT,
-                      arrival_gate TEXT
-                    )
-                    """
-                )
-            )
-            # Insert all the data
-            await conn.execute(
-                text(
-                    """
-                    INSERT INTO flights VALUES (:id, :airline, :flight_number,
-                      :departure_airport, :arrival_airport, :departure_time,
-                      :arrival_time, :departure_gate, :arrival_gate)
-                    """
-                ),
-                [
-                    {
-                        "id": f.id,
-                        "airline": f.airline,
-                        "flight_number": f.flight_number,
-                        "departure_airport": f.departure_airport,
-                        "arrival_airport": f.arrival_airport,
-                        "departure_time": f.departure_time,
-                        "arrival_time": f.arrival_time,
-                        "departure_gate": f.departure_gate,
-                        "arrival_gate": f.arrival_gate,
-                    }
-                    for f in flights
-                ],
-            )
-
-            # If the table already exists, drop it to avoid conflicts
-            await conn.execute(text("DROP TABLE IF EXISTS tickets CASCADE"))
-            # Create a new table
-            await conn.execute(
-                text(
-                    """
-                    CREATE TABLE tickets(
-                        user_id TEXT,
-                        user_name TEXT,
-                        user_email TEXT,
-                        airline TEXT,
-                        flight_number TEXT,
-                        departure_airport TEXT,
-                        arrival_airport TEXT,
-                        departure_time TIMESTAMP,
-                        arrival_time TIMESTAMP
-                    )
-                    """
-                )
-            )
-
-            # If the table already exists, drop it to avoid conflicts
-            await conn.execute(text("DROP TABLE IF EXISTS policies CASCADE"))
-            # Create a new table
-            await conn.execute(
-                text(
-                    """
-                    CREATE TABLE policies(
-                      id INT PRIMARY KEY,
-                      content TEXT NOT NULL,
-                      embedding vector(768) NOT NULL
-                    )
-                    """
-                )
-            )
-            # Insert all the data
-            await conn.execute(
-                text(
-                    """
-                    INSERT INTO policies VALUES (:id, :content, :embedding)
-                    """
-                ),
-                [
-                    {
-                        "id": p.id,
-                        "content": p.content,
-                        "embedding": p.embedding,
-                    }
-                    for p in policies
-                ],
-            )
-            await conn.commit()
+        return await self.__pg_ds.initialize_data(
+            airports, amenities, flights, policies
+        )
 
     async def export_data(
         self,
@@ -302,61 +95,17 @@ class Client(datastore.Client[Config]):
         list[models.Flight],
         list[models.Policy],
     ]:
-        async with self.__pool.connect() as conn:
-            airport_task = asyncio.create_task(
-                conn.execute(text("""SELECT * FROM airports ORDER BY id ASC"""))
-            )
-            amenity_task = asyncio.create_task(
-                conn.execute(text("""SELECT * FROM amenities ORDER BY id ASC"""))
-            )
-            flights_task = asyncio.create_task(
-                conn.execute(text("""SELECT * FROM flights ORDER BY id ASC"""))
-            )
-            policy_task = asyncio.create_task(
-                conn.execute(text("""SELECT * FROM policies ORDER BY id ASC"""))
-            )
-
-            airport_results = (await airport_task).mappings().fetchall()
-            amenity_results = (await amenity_task).mappings().fetchall()
-            flights_results = (await flights_task).mappings().fetchall()
-            policy_results = (await policy_task).mappings().fetchall()
-
-            airports = [models.Airport.model_validate(a) for a in airport_results]
-            amenities = [models.Amenity.model_validate(a) for a in amenity_results]
-            flights = [models.Flight.model_validate(f) for f in flights_results]
-            policies = [models.Policy.model_validate(p) for p in policy_results]
-
-            return airports, amenities, flights, policies
+        return await self.__pg_ds.export_data()
 
     async def get_airport_by_id(
         self, id: int
     ) -> tuple[Optional[models.Airport], Optional[str]]:
-        async with self.__pool.connect() as conn:
-            sql = """SELECT * FROM airports WHERE id=:id"""
-            s = text(sql)
-            params = {"id": id}
-            result = (await conn.execute(s, params)).mappings().fetchone()
-
-        if result is None:
-            return None, sql
-
-        res = models.Airport.model_validate(result)
-        return res, sql
+        return await self.__pg_ds.get_airport_by_id(id)
 
     async def get_airport_by_iata(
         self, iata: str
     ) -> tuple[Optional[models.Airport], Optional[str]]:
-        async with self.__pool.connect() as conn:
-            sql = """SELECT * FROM airports WHERE iata ILIKE :iata"""
-            s = text(sql)
-            params = {"iata": iata}
-            result = (await conn.execute(s, params)).mappings().fetchone()
-
-        if result is None:
-            return None, sql
-
-        res = models.Airport.model_validate(result)
-        return res, sql
+        return await self.__pg_ds.get_airport_by_iata(iata)
 
     async def search_airports(
         self,
@@ -364,104 +113,31 @@ class Client(datastore.Client[Config]):
         city: Optional[str] = None,
         name: Optional[str] = None,
     ) -> tuple[list[models.Airport], Optional[str]]:
-        async with self.__pool.connect() as conn:
-            sql = """
-                SELECT * FROM airports
-                  WHERE (CAST(:country AS TEXT) IS NULL OR country ILIKE :country)
-                  AND (CAST(:city AS TEXT) IS NULL OR city ILIKE :city)
-                  AND (CAST(:name AS TEXT) IS NULL OR name ILIKE '%' || :name || '%')
-                  LIMIT 10
-                """
-            s = text(sql)
-            params = {
-                "country": country,
-                "city": city,
-                "name": name,
-            }
-            results = (await conn.execute(s, params)).mappings().fetchall()
-
-        res = [models.Airport.model_validate(r) for r in results]
-        return res, sql
+        return await self.__pg_ds.search_airports(country, city, name)
 
     async def get_amenity(
         self, id: int
     ) -> tuple[Optional[models.Amenity], Optional[str]]:
-        async with self.__pool.connect() as conn:
-            sql = """
-                SELECT id, name, description, location, terminal, category, hour
-                FROM amenities WHERE id=:id
-                """
-            s = text(sql)
-            params = {"id": id}
-            result = (await conn.execute(s, params)).mappings().fetchone()
-
-        if result is None:
-            return None, None
-
-        res = models.Amenity.model_validate(result)
-        return res, sql
+        return await self.__pg_ds.get_amenity(id)
 
     async def amenities_search(
         self, query_embedding: list[float], similarity_threshold: float, top_k: int
     ) -> tuple[list[Any], Optional[str]]:
-        async with self.__pool.connect() as conn:
-            sql = """
-                SELECT name, description, location, terminal, category, hour
-                FROM amenities
-                WHERE (embedding <=> :query_embedding) < :similarity_threshold
-                ORDER BY (embedding <=> :query_embedding)
-                LIMIT :top_k
-                """
-            s = text(sql)
-            params = {
-                "query_embedding": query_embedding,
-                "similarity_threshold": similarity_threshold,
-                "top_k": top_k,
-            }
-            results = (await conn.execute(s, params)).mappings().fetchall()
-
-        res = [r for r in results]
-        return res, sql
+        return await self.__pg_ds.amenities_search(
+            query_embedding, similarity_threshold, top_k
+        )
 
     async def get_flight(
         self, flight_id: int
     ) -> tuple[Optional[models.Flight], Optional[str]]:
-        async with self.__pool.connect() as conn:
-            sql = """
-                SELECT * FROM flights
-                  WHERE id = :flight_id
-                """
-            s = text(sql)
-            params = {"flight_id": flight_id}
-            result = (await conn.execute(s, params)).mappings().fetchone()
-
-        if result is None:
-            return None, None
-
-        res = models.Flight.model_validate(result)
-        return res, sql
+        return await self.__pg_ds.get_flight(flight_id)
 
     async def search_flights_by_number(
         self,
         airline: str,
         number: str,
     ) -> tuple[list[models.Flight], Optional[str]]:
-        async with self.__pool.connect() as conn:
-            sql = """
-                SELECT * FROM flights
-                  WHERE airline = :airline
-                  AND flight_number = :number
-                  LIMIT 10
-                """
-            s = text(sql)
-            params = {
-                "airline": airline,
-                "number": number,
-            }
-            results = (await conn.execute(s, params)).mappings().fetchall()
-
-        res = [models.Flight.model_validate(r) for r in results]
-        return res, sql
+        return await self.__pg_ds.search_flights_by_number(airline, number)
 
     async def search_flights_by_airports(
         self,
@@ -469,26 +145,9 @@ class Client(datastore.Client[Config]):
         departure_airport: Optional[str] = None,
         arrival_airport: Optional[str] = None,
     ) -> tuple[list[models.Flight], Optional[str]]:
-        async with self.__pool.connect() as conn:
-            sql = """
-                SELECT * FROM flights
-                  WHERE (CAST(:departure_airport AS TEXT) IS NULL OR departure_airport ILIKE :departure_airport)
-                  AND (CAST(:arrival_airport AS TEXT) IS NULL OR arrival_airport ILIKE :arrival_airport)
-                  AND departure_time >= CAST(:datetime AS timestamp)
-                  AND departure_time < CAST(:datetime AS timestamp) + interval '1 day'
-                  LIMIT 10
-                """
-            s = text(sql)
-            params = {
-                "departure_airport": departure_airport,
-                "arrival_airport": arrival_airport,
-                "datetime": datetime.strptime(date, "%Y-%m-%d"),
-            }
-
-            results = (await conn.execute(s, params)).mappings().fetchall()
-
-        res = [models.Flight.model_validate(r) for r in results]
-        return res, sql
+        return await self.__pg_ds.search_flights_by_airports(
+            date, departure_airport, arrival_airport
+        )
 
     async def validate_ticket(
         self,
@@ -497,28 +156,9 @@ class Client(datastore.Client[Config]):
         departure_airport: str,
         departure_time: str,
     ) -> tuple[Optional[models.Flight], Optional[str]]:
-        departure_time_datetime = datetime.strptime(departure_time, "%Y-%m-%d %H:%M:%S")
-        async with self.__pool.connect() as conn:
-            sql = """
-                    SELECT * FROM flights
-                    WHERE airline ILIKE :airline
-                    AND flight_number ILIKE :flight_number
-                    AND departure_airport ILIKE :departure_airport
-                    AND departure_time = :departure_time
-                """
-            s = text(sql)
-            params = {
-                "airline": airline,
-                "flight_number": flight_number,
-                "departure_airport": departure_airport,
-                "departure_time": departure_time_datetime,
-            }
-            result = (await conn.execute(s, params)).mappings().fetchone()
-
-        if result is None:
-            return None, None
-        res = models.Flight.model_validate(result)
-        return res, sql
+        return await self.__pg_ds.validate_ticket(
+            airline, flight_number, departure_airport, departure_time
+        )
 
     async def insert_ticket(
         self,
@@ -532,90 +172,30 @@ class Client(datastore.Client[Config]):
         departure_time: str,
         arrival_time: str,
     ):
-        departure_time_datetime = datetime.strptime(departure_time, "%Y-%m-%d %H:%M:%S")
-        arrival_time_datetime = datetime.strptime(arrival_time, "%Y-%m-%d %H:%M:%S")
-
-        async with self.__pool.connect() as conn:
-            s = text(
-                """
-                INSERT INTO tickets (
-                    user_id,
-                    user_name,
-                    user_email,
-                    airline,
-                    flight_number,
-                    departure_airport,
-                    arrival_airport,
-                    departure_time,
-                    arrival_time
-                ) VALUES (
-                    :user_id,
-                    :user_name,
-                    :user_email,
-                    :airline,
-                    :flight_number,
-                    :departure_airport,
-                    :arrival_airport,
-                    :departure_time,
-                    :arrival_time
-                );
-            """
-            )
-            params = {
-                "user_id": user_id,
-                "user_name": user_name,
-                "user_email": user_email,
-                "airline": airline,
-                "flight_number": flight_number,
-                "departure_airport": departure_airport,
-                "arrival_airport": arrival_airport,
-                "departure_time": departure_time_datetime,
-                "arrival_time": arrival_time_datetime,
-            }
-            result = (await conn.execute(s, params)).mappings()
-            await conn.commit()
-            if not result:
-                raise Exception("Ticket Insertion failure")
+        return await self.__pg_ds.insert_ticket(
+            user_id,
+            user_name,
+            user_email,
+            airline,
+            flight_number,
+            departure_airport,
+            arrival_airport,
+            departure_time,
+            arrival_time,
+        )
 
     async def list_tickets(
         self,
         user_id: str,
     ) -> tuple[list[Any], Optional[str]]:
-        async with self.__pool.connect() as conn:
-            sql = """
-                SELECT user_name, airline, flight_number, departure_airport, arrival_airport, departure_time, arrival_time FROM tickets
-                WHERE user_id = :user_id
-                """
-            s = text(sql)
-            params = {
-                "user_id": user_id,
-            }
-            results = (await conn.execute(s, params)).mappings().fetchall()
-
-        res = [r for r in results]
-        return res, sql
+        return await self.__pg_ds.list_tickets(user_id)
 
     async def policies_search(
         self, query_embedding: list[float], similarity_threshold: float, top_k: int
     ) -> tuple[list[str], Optional[str]]:
-        async with self.__pool.connect() as conn:
-            sql = """
-                SELECT content
-                FROM policies
-                WHERE (embedding <=> :query_embedding) < :similarity_threshold
-                ORDER BY (embedding <=> :query_embedding)
-                LIMIT :top_k
-                """
-            s = text(sql)
-            params = {
-                "query_embedding": query_embedding,
-                "similarity_threshold": similarity_threshold,
-                "top_k": top_k,
-            }
-            results = (await conn.execute(s, params)).mappings().fetchall()
-
-        res = [r["content"] for r in results]
-        return res, sql
+        return await self.__pg_ds.policies_search(
+            query_embedding, similarity_threshold, top_k
+        )
 
     async def close(self):
-        await self.__pool.dispose()
+        return await self.__pg_ds.close()

--- a/retrieval_service/datastore/providers/cloudsql_postgres.py
+++ b/retrieval_service/datastore/providers/cloudsql_postgres.py
@@ -13,19 +13,18 @@
 # limitations under the License.
 
 import asyncio
-from datetime import datetime
 from typing import Any, Literal, Optional
 
 import asyncpg
 from google.cloud.sql.connector import Connector, RefreshStrategy
 from pgvector.asyncpg import register_vector
 from pydantic import BaseModel
-from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 import models
 
 from .. import datastore
+from .postgres_datastore import PostgresDatastore
 
 CLOUD_SQL_PG_IDENTIFIER = "cloudsql-postgres"
 
@@ -41,7 +40,7 @@ class Config(BaseModel, datastore.AbstractConfig):
 
 
 class Client(datastore.Client[Config]):
-    __pool: AsyncEngine
+    __pg_ds: PostgresDatastore
     __connector: Optional[Connector] = None
 
     @datastore.classproperty
@@ -49,7 +48,7 @@ class Client(datastore.Client[Config]):
         return CLOUD_SQL_PG_IDENTIFIER
 
     def __init__(self, pool: AsyncEngine):
-        self.__pool = pool
+        self.__pg_ds = PostgresDatastore(pool)
 
     @classmethod
     async def create(cls, config: Config) -> "Client":
@@ -86,214 +85,9 @@ class Client(datastore.Client[Config]):
         flights: list[models.Flight],
         policies: list[models.Policy],
     ) -> None:
-        async with self.__pool.connect() as conn:
-            # If the table already exists, drop it to avoid conflicts
-            await conn.execute(text("DROP TABLE IF EXISTS airports CASCADE"))
-            # Create a new table
-            await conn.execute(
-                text(
-                    """
-                    CREATE TABLE airports(
-                      id INT PRIMARY KEY,
-                      iata TEXT,
-                      name TEXT,
-                      city TEXT,
-                      country TEXT
-                    )
-                    """
-                )
-            )
-            # Insert all the data
-            await conn.execute(
-                text(
-                    """INSERT INTO airports VALUES (:id, :iata, :name, :city, :country)"""
-                ),
-                [
-                    {
-                        "id": a.id,
-                        "iata": a.iata,
-                        "name": a.name,
-                        "city": a.city,
-                        "country": a.country,
-                    }
-                    for a in airports
-                ],
-            )
-
-            await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
-            # If the table already exists, drop it to avoid conflicts
-            await conn.execute(text("DROP TABLE IF EXISTS amenities CASCADE"))
-            # Create a new table
-            await conn.execute(
-                text(
-                    """
-                    CREATE TABLE amenities(
-                      id INT PRIMARY KEY,
-                      name TEXT,
-                      description TEXT,
-                      location TEXT,
-                      terminal TEXT,
-                      category TEXT,
-                      hour TEXT,
-                      sunday_start_hour TIME,
-                      sunday_end_hour TIME,
-                      monday_start_hour TIME,
-                      monday_end_hour TIME,
-                      tuesday_start_hour TIME,
-                      tuesday_end_hour TIME,
-                      wednesday_start_hour TIME,
-                      wednesday_end_hour TIME,
-                      thursday_start_hour TIME,
-                      thursday_end_hour TIME,
-                      friday_start_hour TIME,
-                      friday_end_hour TIME,
-                      saturday_start_hour TIME,
-                      saturday_end_hour TIME,
-                      content TEXT NOT NULL,
-                      embedding vector(768) NOT NULL
-                    )
-                    """
-                )
-            )
-            # Insert all the data
-            await conn.execute(
-                text(
-                    """
-                    INSERT INTO amenities VALUES (:id, :name, :description, :location,
-                      :terminal, :category, :hour, :sunday_start_hour, :sunday_end_hour,
-                      :monday_start_hour, :monday_end_hour, :tuesday_start_hour,
-                      :tuesday_end_hour, :wednesday_start_hour, :wednesday_end_hour,
-                      :thursday_start_hour, :thursday_end_hour, :friday_start_hour,
-                      :friday_end_hour, :saturday_start_hour, :saturday_end_hour, :content, :embedding)
-                    """
-                ),
-                [
-                    {
-                        "id": a.id,
-                        "name": a.name,
-                        "description": a.description,
-                        "location": a.location,
-                        "terminal": a.terminal,
-                        "category": a.category,
-                        "hour": a.hour,
-                        "sunday_start_hour": a.sunday_start_hour,
-                        "sunday_end_hour": a.sunday_end_hour,
-                        "monday_start_hour": a.monday_start_hour,
-                        "monday_end_hour": a.monday_end_hour,
-                        "tuesday_start_hour": a.tuesday_start_hour,
-                        "tuesday_end_hour": a.tuesday_end_hour,
-                        "wednesday_start_hour": a.wednesday_start_hour,
-                        "wednesday_end_hour": a.wednesday_end_hour,
-                        "thursday_start_hour": a.thursday_start_hour,
-                        "thursday_end_hour": a.thursday_end_hour,
-                        "friday_start_hour": a.friday_start_hour,
-                        "friday_end_hour": a.friday_end_hour,
-                        "saturday_start_hour": a.saturday_start_hour,
-                        "saturday_end_hour": a.saturday_end_hour,
-                        "content": a.content,
-                        "embedding": a.embedding,
-                    }
-                    for a in amenities
-                ],
-            )
-
-            # If the table already exists, drop it to avoid conflicts
-            await conn.execute(text("DROP TABLE IF EXISTS flights CASCADE"))
-            # Create a new table
-            await conn.execute(
-                text(
-                    """
-                    CREATE TABLE flights(
-                      id INTEGER PRIMARY KEY,
-                      airline TEXT,
-                      flight_number TEXT,
-                      departure_airport TEXT,
-                      arrival_airport TEXT,
-                      departure_time TIMESTAMP,
-                      arrival_time TIMESTAMP,
-                      departure_gate TEXT,
-                      arrival_gate TEXT
-                    )
-                    """
-                )
-            )
-            # Insert all the data
-            await conn.execute(
-                text(
-                    """
-                    INSERT INTO flights VALUES (:id, :airline, :flight_number,
-                      :departure_airport, :arrival_airport, :departure_time,
-                      :arrival_time, :departure_gate, :arrival_gate)
-                    """
-                ),
-                [
-                    {
-                        "id": f.id,
-                        "airline": f.airline,
-                        "flight_number": f.flight_number,
-                        "departure_airport": f.departure_airport,
-                        "arrival_airport": f.arrival_airport,
-                        "departure_time": f.departure_time,
-                        "arrival_time": f.arrival_time,
-                        "departure_gate": f.departure_gate,
-                        "arrival_gate": f.arrival_gate,
-                    }
-                    for f in flights
-                ],
-            )
-
-            # If the table already exists, drop it to avoid conflicts
-            await conn.execute(text("DROP TABLE IF EXISTS tickets CASCADE"))
-            # Create a new table
-            await conn.execute(
-                text(
-                    """
-                    CREATE TABLE tickets(
-                        user_id TEXT,
-                        user_name TEXT,
-                        user_email TEXT,
-                        airline TEXT,
-                        flight_number TEXT,
-                        departure_airport TEXT,
-                        arrival_airport TEXT,
-                        departure_time TIMESTAMP,
-                        arrival_time TIMESTAMP
-                    )
-                    """
-                )
-            )
-
-            # If the table already exists, drop it to avoid conflicts
-            await conn.execute(text("DROP TABLE IF EXISTS policies CASCADE"))
-            # Create a new table
-            await conn.execute(
-                text(
-                    """
-                    CREATE TABLE policies(
-                      id INT PRIMARY KEY,
-                      content TEXT NOT NULL,
-                      embedding vector(768) NOT NULL
-                    )
-                    """
-                )
-            )
-            # Insert all the data
-            await conn.execute(
-                text(
-                    """
-                    INSERT INTO policies VALUES (:id, :content, :embedding)
-                    """
-                ),
-                [
-                    {
-                        "id": p.id,
-                        "content": p.content,
-                        "embedding": p.embedding,
-                    }
-                    for p in policies
-                ],
-            )
-            await conn.commit()
+        return await self.__pg_ds.initialize_data(
+            airports, amenities, flights, policies
+        )
 
     async def export_data(
         self,
@@ -303,59 +97,17 @@ class Client(datastore.Client[Config]):
         list[models.Flight],
         list[models.Policy],
     ]:
-        async with self.__pool.connect() as conn:
-            airport_task = asyncio.create_task(
-                conn.execute(text("""SELECT * FROM airports ORDER BY id ASC"""))
-            )
-            amenity_task = asyncio.create_task(
-                conn.execute(text("""SELECT * FROM amenities ORDER BY id ASC"""))
-            )
-            flights_task = asyncio.create_task(
-                conn.execute(text("""SELECT * FROM flights ORDER BY id ASC"""))
-            )
-            policy_task = asyncio.create_task(
-                conn.execute(text("""SELECT * FROM policies ORDER BY id ASC"""))
-            )
-
-            airport_results = (await airport_task).mappings().fetchall()
-            amenity_results = (await amenity_task).mappings().fetchall()
-            flights_results = (await flights_task).mappings().fetchall()
-            policy_results = (await policy_task).mappings().fetchall()
-
-            airports = [models.Airport.model_validate(a) for a in airport_results]
-            amenities = [models.Amenity.model_validate(a) for a in amenity_results]
-            flights = [models.Flight.model_validate(f) for f in flights_results]
-            policies = [models.Policy.model_validate(p) for p in policy_results]
-
-            return airports, amenities, flights, policies
+        return await self.__pg_ds.export_data()
 
     async def get_airport_by_id(
         self, id: int
     ) -> tuple[Optional[models.Airport], Optional[str]]:
-        async with self.__pool.connect() as conn:
-            s = text("""SELECT * FROM airports WHERE id=:id""")
-            params = {"id": id}
-            result = (await conn.execute(s, params)).mappings().fetchone()
-
-        if result is None:
-            return None, None
-
-        res = models.Airport.model_validate(result)
-        return res, None
+        return await self.__pg_ds.get_airport_by_id(id)
 
     async def get_airport_by_iata(
         self, iata: str
     ) -> tuple[Optional[models.Airport], Optional[str]]:
-        async with self.__pool.connect() as conn:
-            s = text("""SELECT * FROM airports WHERE iata ILIKE :iata""")
-            params = {"iata": iata}
-            result = (await conn.execute(s, params)).mappings().fetchone()
-
-        if result is None:
-            return None, None
-
-        res = models.Airport.model_validate(result)
-        return res, None
+        return await self.__pg_ds.get_airport_by_iata(iata)
 
     async def search_airports(
         self,
@@ -363,109 +115,31 @@ class Client(datastore.Client[Config]):
         city: Optional[str] = None,
         name: Optional[str] = None,
     ) -> tuple[list[models.Airport], Optional[str]]:
-        async with self.__pool.connect() as conn:
-            s = text(
-                """
-                SELECT * FROM airports
-                  WHERE (CAST(:country AS TEXT) IS NULL OR country ILIKE :country)
-                  AND (CAST(:city AS TEXT) IS NULL OR city ILIKE :city)
-                  AND (CAST(:name AS TEXT) IS NULL OR name ILIKE '%' || :name || '%')
-                  LIMIT 10
-                """
-            )
-            params = {
-                "country": country,
-                "city": city,
-                "name": name,
-            }
-            results = (await conn.execute(s, params)).mappings().fetchall()
-
-        res = [models.Airport.model_validate(r) for r in results]
-        return res, None
+        return await self.__pg_ds.search_airports(country, city, name)
 
     async def get_amenity(
         self, id: int
     ) -> tuple[Optional[models.Amenity], Optional[str]]:
-        async with self.__pool.connect() as conn:
-            s = text(
-                """
-                SELECT id, name, description, location, terminal, category, hour
-                FROM amenities WHERE id=:id
-                """
-            )
-            params = {"id": id}
-            result = (await conn.execute(s, params)).mappings().fetchone()
-
-        if result is None:
-            return None, None
-
-        res = models.Amenity.model_validate(result)
-        return res, None
+        return await self.__pg_ds.get_amenity(id)
 
     async def amenities_search(
         self, query_embedding: list[float], similarity_threshold: float, top_k: int
     ) -> tuple[list[Any], Optional[str]]:
-        async with self.__pool.connect() as conn:
-            s = text(
-                """
-                SELECT name, description, location, terminal, category, hour
-                  FROM amenities
-                  WHERE (embedding <=> :query_embedding) < :similarity_threshold
-                  ORDER BY (embedding <=> :query_embedding)
-                  LIMIT :top_k
-                """
-            )
-            params = {
-                "query_embedding": query_embedding,
-                "similarity_threshold": similarity_threshold,
-                "top_k": top_k,
-            }
-            results = (await conn.execute(s, params)).mappings().fetchall()
-
-        res = [r for r in results]
-        return res, None
+        return await self.__pg_ds.amenities_search(
+            query_embedding, similarity_threshold, top_k
+        )
 
     async def get_flight(
         self, flight_id: int
     ) -> tuple[Optional[models.Flight], Optional[str]]:
-        async with self.__pool.connect() as conn:
-            s = text(
-                """
-                SELECT * FROM flights
-                  WHERE id = :flight_id
-                """
-            )
-            params = {"flight_id": flight_id}
-            result = (await conn.execute(s, params)).mappings().fetchone()
-
-        if result is None:
-            return None, None
-
-        res = models.Flight.model_validate(result)
-        return res, None
+        return await self.__pg_ds.get_flight(flight_id)
 
     async def search_flights_by_number(
         self,
         airline: str,
         number: str,
     ) -> tuple[list[models.Flight], Optional[str]]:
-        async with self.__pool.connect() as conn:
-            s = text(
-                """
-                SELECT * FROM flights
-                  WHERE airline = :airline
-                  AND flight_number = :number
-                  LIMIT 10
-                """
-            )
-            params = {
-                "airline": airline,
-                "number": number,
-            }
-            results = (await conn.execute(s, params)).mappings().fetchall()
-
-        res = [models.Flight.model_validate(r) for r in results]
-        return res, None
+        return await self.__pg_ds.search_flights_by_number(airline, number)
 
     async def search_flights_by_airports(
         self,
@@ -473,27 +147,9 @@ class Client(datastore.Client[Config]):
         departure_airport: Optional[str] = None,
         arrival_airport: Optional[str] = None,
     ) -> tuple[list[models.Flight], Optional[str]]:
-        async with self.__pool.connect() as conn:
-            s = text(
-                """
-                SELECT * FROM flights
-                  WHERE (CAST(:departure_airport AS TEXT) IS NULL OR departure_airport ILIKE :departure_airport)
-                  AND (CAST(:arrival_airport AS TEXT) IS NULL OR arrival_airport ILIKE :arrival_airport)
-                  AND departure_time >= CAST(:datetime AS timestamp)
-                  AND departure_time < CAST(:datetime AS timestamp) + interval '1 day'
-                  LIMIT 10
-                """
-            )
-            params = {
-                "departure_airport": departure_airport,
-                "arrival_airport": arrival_airport,
-                "datetime": datetime.strptime(date, "%Y-%m-%d"),
-            }
-
-            results = (await conn.execute(s, params)).mappings().fetchall()
-
-        res = [models.Flight.model_validate(r) for r in results]
-        return res, None
+        return await self.__pg_ds.search_flights_by_airports(
+            date, departure_airport, arrival_airport
+        )
 
     async def validate_ticket(
         self,
@@ -502,29 +158,9 @@ class Client(datastore.Client[Config]):
         departure_airport: str,
         departure_time: str,
     ) -> tuple[Optional[models.Flight], Optional[str]]:
-        departure_time_datetime = datetime.strptime(departure_time, "%Y-%m-%d %H:%M:%S")
-        async with self.__pool.connect() as conn:
-            s = text(
-                """
-                    SELECT * FROM flights
-                    WHERE airline ILIKE :airline
-                    AND flight_number ILIKE :flight_number
-                    AND departure_airport ILIKE :departure_airport
-                    AND departure_time = :departure_time
-                """
-            )
-            params = {
-                "airline": airline,
-                "flight_number": flight_number,
-                "departure_airport": departure_airport,
-                "departure_time": departure_time_datetime,
-            }
-            result = (await conn.execute(s, params)).mappings().fetchone()
-
-        if result is None:
-            return None, None
-        res = models.Flight.model_validate(result)
-        return res, None
+        return await self.__pg_ds.validate_ticket(
+            airline, flight_number, departure_airport, departure_time
+        )
 
     async def insert_ticket(
         self,
@@ -538,92 +174,30 @@ class Client(datastore.Client[Config]):
         departure_time: str,
         arrival_time: str,
     ):
-        departure_time_datetime = datetime.strptime(departure_time, "%Y-%m-%d %H:%M:%S")
-        arrival_time_datetime = datetime.strptime(arrival_time, "%Y-%m-%d %H:%M:%S")
-
-        async with self.__pool.connect() as conn:
-            s = text(
-                """
-                INSERT INTO tickets (
-                    user_id,
-                    user_name,
-                    user_email,
-                    airline,
-                    flight_number,
-                    departure_airport,
-                    arrival_airport,
-                    departure_time,
-                    arrival_time
-                ) VALUES (
-                    :user_id,
-                    :user_name,
-                    :user_email,
-                    :airline,
-                    :flight_number,
-                    :departure_airport,
-                    :arrival_airport,
-                    :departure_time,
-                    :arrival_time
-                );
-            """
-            )
-            params = {
-                "user_id": user_id,
-                "user_name": user_name,
-                "user_email": user_email,
-                "airline": airline,
-                "flight_number": flight_number,
-                "departure_airport": departure_airport,
-                "arrival_airport": arrival_airport,
-                "departure_time": departure_time_datetime,
-                "arrival_time": arrival_time_datetime,
-            }
-            result = (await conn.execute(s, params)).mappings()
-            await conn.commit()
-            if not result:
-                raise Exception("Ticket Insertion failure")
+        return await self.__pg_ds.insert_ticket(
+            user_id,
+            user_name,
+            user_email,
+            airline,
+            flight_number,
+            departure_airport,
+            arrival_airport,
+            departure_time,
+            arrival_time,
+        )
 
     async def list_tickets(
         self,
         user_id: str,
     ) -> tuple[list[Any], Optional[str]]:
-        async with self.__pool.connect() as conn:
-            s = text(
-                """
-                SELECT user_name, airline, flight_number, departure_airport, arrival_airport, departure_time, arrival_time FROM tickets
-                WHERE user_id = :user_id
-                """
-            )
-            params = {
-                "user_id": user_id,
-            }
-            results = (await conn.execute(s, params)).mappings().fetchall()
-
-        res = [r for r in results]
-        return res, None
+        return await self.__pg_ds.list_tickets(user_id)
 
     async def policies_search(
         self, query_embedding: list[float], similarity_threshold: float, top_k: int
     ) -> tuple[list[str], Optional[str]]:
-        async with self.__pool.connect() as conn:
-            s = text(
-                """
-                SELECT content
-                  FROM policies 
-                  WHERE (embedding <=> :query_embedding) < :similarity_threshold
-                  ORDER BY (embedding <=> :query_embedding)
-                  LIMIT :top_k
-                """
-            )
-            params = {
-                "query_embedding": query_embedding,
-                "similarity_threshold": similarity_threshold,
-                "top_k": top_k,
-            }
-            results = (await conn.execute(s, params)).mappings().fetchall()
-
-        res = [r["content"] for r in results]
-        return res, None
+        return await self.__pg_ds.policies_search(
+            query_embedding, similarity_threshold, top_k
+        )
 
     async def close(self):
-        await self.__pool.dispose()
+        await self.__pg_ds.close()

--- a/retrieval_service/datastore/providers/cloudsql_postgres_test.py
+++ b/retrieval_service/datastore/providers/cloudsql_postgres_test.py
@@ -198,7 +198,7 @@ async def test_get_airport_by_id(ds: cloudsql_postgres.Client):
         country="Papua New Guinea",
     )
     assert res == expected
-    assert sql is None
+    assert sql is not None
 
 
 @pytest.mark.parametrize(
@@ -218,7 +218,7 @@ async def test_get_airport_by_iata(ds: cloudsql_postgres.Client, iata: str):
         country="United States",
     )
     assert res == expected
-    assert sql is None
+    assert sql is not None
 
 
 search_airports_test_data = [
@@ -301,7 +301,7 @@ async def test_search_airports(
 ):
     res, sql = await ds.search_airports(country, city, name)
     assert res == expected
-    assert sql is None
+    assert sql is not None
 
 
 async def test_get_amenity(ds: cloudsql_postgres.Client):
@@ -330,7 +330,7 @@ async def test_get_amenity(ds: cloudsql_postgres.Client):
         saturday_end_hour=None,
     )
     assert res == expected
-    assert sql is None
+    assert sql is not None
 
 
 amenities_search_test_data = [
@@ -399,7 +399,7 @@ async def test_amenities_search(
 ):
     res, sql = await ds.amenities_search(query_embedding, similarity_threshold, top_k)
     assert res == expected
-    assert sql is None
+    assert sql is not None
 
 
 async def test_get_flight(ds: cloudsql_postgres.Client):
@@ -416,7 +416,7 @@ async def test_get_flight(ds: cloudsql_postgres.Client):
         arrival_gate="D30",
     )
     assert res == expected
-    assert sql is None
+    assert sql is not None
 
 
 search_flights_by_number_test_data = [
@@ -477,7 +477,7 @@ async def test_search_flights_by_number(
 ):
     res, sql = await ds.search_flights_by_number(airline, number)
     assert res == expected
-    assert sql is None
+    assert sql is not None
 
 
 search_flights_by_airports_test_data = [
@@ -604,7 +604,7 @@ async def test_search_flights_by_airports(
         date, departure_airport, arrival_airport
     )
     assert res == expected
-    assert sql is None
+    assert sql is not None
 
 
 async def test_insert_ticket(ds: cloudsql_postgres.Client):
@@ -640,7 +640,7 @@ async def test_list_tickets(ds: cloudsql_postgres.Client):
     ]
 
     assert res == expected
-    assert sql is None
+    assert sql is not None
 
 
 async def test_validate_ticket(ds: cloudsql_postgres.Client):
@@ -657,7 +657,7 @@ async def test_validate_ticket(ds: cloudsql_postgres.Client):
         arrival_gate="D6",
     )
     assert res == expected
-    assert sql is None
+    assert sql is not None
 
 
 policies_search_test_data = [
@@ -705,4 +705,4 @@ async def test_policies_search(
 ):
     res, sql = await ds.policies_search(query_embedding, similarity_threshold, top_k)
     assert res == expected
-    assert sql is None
+    assert sql is not None

--- a/retrieval_service/datastore/providers/postgres_datastore.py
+++ b/retrieval_service/datastore/providers/postgres_datastore.py
@@ -1,0 +1,569 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from datetime import datetime
+from typing import Any, Optional
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+import models
+
+
+class PostgresDatastore:
+    def __init__(self, pool: AsyncEngine):
+        self.__pool = pool
+
+    async def initialize_data(
+        self,
+        airports: list[models.Airport],
+        amenities: list[models.Amenity],
+        flights: list[models.Flight],
+        policies: list[models.Policy],
+    ) -> None:
+        async with self.__pool.connect() as conn:
+            # If the table already exists, drop it to avoid conflicts
+            await conn.execute(text("DROP TABLE IF EXISTS airports CASCADE"))
+            # Create a new table
+            await conn.execute(
+                text(
+                    """
+                    CREATE TABLE airports(
+                      id INT PRIMARY KEY,
+                      iata TEXT,
+                      name TEXT,
+                      city TEXT,
+                      country TEXT
+                    )
+                    """
+                )
+            )
+            # Insert all the data
+            await conn.execute(
+                text(
+                    """INSERT INTO airports VALUES (:id, :iata, :name, :city, :country)"""
+                ),
+                [
+                    {
+                        "id": a.id,
+                        "iata": a.iata,
+                        "name": a.name,
+                        "city": a.city,
+                        "country": a.country,
+                    }
+                    for a in airports
+                ],
+            )
+
+            await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+            # If the table already exists, drop it to avoid conflicts
+            await conn.execute(text("DROP TABLE IF EXISTS amenities CASCADE"))
+            # Create a new table
+            await conn.execute(
+                text(
+                    """
+                    CREATE TABLE amenities(
+                      id INT PRIMARY KEY,
+                      name TEXT,
+                      description TEXT,
+                      location TEXT,
+                      terminal TEXT,
+                      category TEXT,
+                      hour TEXT,
+                      sunday_start_hour TIME,
+                      sunday_end_hour TIME,
+                      monday_start_hour TIME,
+                      monday_end_hour TIME,
+                      tuesday_start_hour TIME,
+                      tuesday_end_hour TIME,
+                      wednesday_start_hour TIME,
+                      wednesday_end_hour TIME,
+                      thursday_start_hour TIME,
+                      thursday_end_hour TIME,
+                      friday_start_hour TIME,
+                      friday_end_hour TIME,
+                      saturday_start_hour TIME,
+                      saturday_end_hour TIME,
+                      content TEXT NOT NULL,
+                      embedding vector(768) NOT NULL
+                    )
+                    """
+                )
+            )
+            # Insert all the data
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO amenities VALUES (:id, :name, :description, :location,
+                      :terminal, :category, :hour, :sunday_start_hour, :sunday_end_hour,
+                      :monday_start_hour, :monday_end_hour, :tuesday_start_hour,
+                      :tuesday_end_hour, :wednesday_start_hour, :wednesday_end_hour,
+                      :thursday_start_hour, :thursday_end_hour, :friday_start_hour,
+                      :friday_end_hour, :saturday_start_hour, :saturday_end_hour, :content, :embedding)
+                    """
+                ),
+                [
+                    {
+                        "id": a.id,
+                        "name": a.name,
+                        "description": a.description,
+                        "location": a.location,
+                        "terminal": a.terminal,
+                        "category": a.category,
+                        "hour": a.hour,
+                        "sunday_start_hour": a.sunday_start_hour,
+                        "sunday_end_hour": a.sunday_end_hour,
+                        "monday_start_hour": a.monday_start_hour,
+                        "monday_end_hour": a.monday_end_hour,
+                        "tuesday_start_hour": a.tuesday_start_hour,
+                        "tuesday_end_hour": a.tuesday_end_hour,
+                        "wednesday_start_hour": a.wednesday_start_hour,
+                        "wednesday_end_hour": a.wednesday_end_hour,
+                        "thursday_start_hour": a.thursday_start_hour,
+                        "thursday_end_hour": a.thursday_end_hour,
+                        "friday_start_hour": a.friday_start_hour,
+                        "friday_end_hour": a.friday_end_hour,
+                        "saturday_start_hour": a.saturday_start_hour,
+                        "saturday_end_hour": a.saturday_end_hour,
+                        "content": a.content,
+                        "embedding": a.embedding,
+                    }
+                    for a in amenities
+                ],
+            )
+
+            # If the table already exists, drop it to avoid conflicts
+            await conn.execute(text("DROP TABLE IF EXISTS flights CASCADE"))
+            # Create a new table
+            await conn.execute(
+                text(
+                    """
+                    CREATE TABLE flights(
+                      id INTEGER PRIMARY KEY,
+                      airline TEXT,
+                      flight_number TEXT,
+                      departure_airport TEXT,
+                      arrival_airport TEXT,
+                      departure_time TIMESTAMP,
+                      arrival_time TIMESTAMP,
+                      departure_gate TEXT,
+                      arrival_gate TEXT
+                    )
+                    """
+                )
+            )
+            # Insert all the data
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO flights VALUES (:id, :airline, :flight_number,
+                      :departure_airport, :arrival_airport, :departure_time,
+                      :arrival_time, :departure_gate, :arrival_gate)
+                    """
+                ),
+                [
+                    {
+                        "id": f.id,
+                        "airline": f.airline,
+                        "flight_number": f.flight_number,
+                        "departure_airport": f.departure_airport,
+                        "arrival_airport": f.arrival_airport,
+                        "departure_time": f.departure_time,
+                        "arrival_time": f.arrival_time,
+                        "departure_gate": f.departure_gate,
+                        "arrival_gate": f.arrival_gate,
+                    }
+                    for f in flights
+                ],
+            )
+
+            # If the table already exists, drop it to avoid conflicts
+            await conn.execute(text("DROP TABLE IF EXISTS tickets CASCADE"))
+            # Create a new table
+            await conn.execute(
+                text(
+                    """
+                    CREATE TABLE tickets(
+                        user_id TEXT,
+                        user_name TEXT,
+                        user_email TEXT,
+                        airline TEXT,
+                        flight_number TEXT,
+                        departure_airport TEXT,
+                        arrival_airport TEXT,
+                        departure_time TIMESTAMP,
+                        arrival_time TIMESTAMP
+                    )
+                    """
+                )
+            )
+
+            # If the table already exists, drop it to avoid conflicts
+            await conn.execute(text("DROP TABLE IF EXISTS policies CASCADE"))
+            # Create a new table
+            await conn.execute(
+                text(
+                    """
+                    CREATE TABLE policies(
+                      id INT PRIMARY KEY,
+                      content TEXT NOT NULL,
+                      embedding vector(768) NOT NULL
+                    )
+                    """
+                )
+            )
+            # Insert all the data
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO policies VALUES (:id, :content, :embedding)
+                    """
+                ),
+                [
+                    {
+                        "id": p.id,
+                        "content": p.content,
+                        "embedding": p.embedding,
+                    }
+                    for p in policies
+                ],
+            )
+            await conn.commit()
+
+    async def export_data(
+        self,
+    ) -> tuple[
+        list[models.Airport],
+        list[models.Amenity],
+        list[models.Flight],
+        list[models.Policy],
+    ]:
+        async with self.__pool.connect() as conn:
+            airport_task = asyncio.create_task(
+                conn.execute(text("""SELECT * FROM airports ORDER BY id ASC"""))
+            )
+            amenity_task = asyncio.create_task(
+                conn.execute(text("""SELECT * FROM amenities ORDER BY id ASC"""))
+            )
+            flights_task = asyncio.create_task(
+                conn.execute(text("""SELECT * FROM flights ORDER BY id ASC"""))
+            )
+            policy_task = asyncio.create_task(
+                conn.execute(text("""SELECT * FROM policies ORDER BY id ASC"""))
+            )
+
+            airport_results = (await airport_task).mappings().fetchall()
+            amenity_results = (await amenity_task).mappings().fetchall()
+            flights_results = (await flights_task).mappings().fetchall()
+            policy_results = (await policy_task).mappings().fetchall()
+
+            airports = [models.Airport.model_validate(a) for a in airport_results]
+            amenities = [models.Amenity.model_validate(a) for a in amenity_results]
+            flights = [models.Flight.model_validate(f) for f in flights_results]
+            policies = [models.Policy.model_validate(p) for p in policy_results]
+
+            return airports, amenities, flights, policies
+
+    async def get_airport_by_id(
+        self, id: int
+    ) -> tuple[Optional[models.Airport], Optional[str]]:
+        async with self.__pool.connect() as conn:
+            sql = """SELECT * FROM airports WHERE id=:id"""
+            s = text(sql)
+            params = {"id": id}
+            result = (await conn.execute(s, params)).mappings().fetchone()
+
+        if result is None:
+            return None, None
+
+        res = models.Airport.model_validate(result)
+        return res, sql
+
+    async def get_airport_by_iata(
+        self, iata: str
+    ) -> tuple[Optional[models.Airport], Optional[str]]:
+        async with self.__pool.connect() as conn:
+            sql = """SELECT * FROM airports WHERE iata ILIKE :iata"""
+            s = text(sql)
+            params = {"iata": iata}
+            result = (await conn.execute(s, params)).mappings().fetchone()
+
+        if result is None:
+            return None, None
+
+        res = models.Airport.model_validate(result)
+        return res, sql
+
+    async def search_airports(
+        self,
+        country: Optional[str] = None,
+        city: Optional[str] = None,
+        name: Optional[str] = None,
+    ) -> tuple[list[models.Airport], Optional[str]]:
+        async with self.__pool.connect() as conn:
+            sql = """
+                SELECT * FROM airports
+                  WHERE (CAST(:country AS TEXT) IS NULL OR country ILIKE :country)
+                  AND (CAST(:city AS TEXT) IS NULL OR city ILIKE :city)
+                  AND (CAST(:name AS TEXT) IS NULL OR name ILIKE '%' || :name || '%')
+                  LIMIT 10
+                """
+            s = text(sql)
+            params = {
+                "country": country,
+                "city": city,
+                "name": name,
+            }
+            results = (await conn.execute(s, params)).mappings().fetchall()
+
+        res = [models.Airport.model_validate(r) for r in results]
+        return res, sql
+
+    async def get_amenity(
+        self, id: int
+    ) -> tuple[Optional[models.Amenity], Optional[str]]:
+        async with self.__pool.connect() as conn:
+            sql = """
+                SELECT id, name, description, location, terminal, category, hour
+                FROM amenities WHERE id=:id
+                """
+            s = text(sql)
+            params = {"id": id}
+            result = (await conn.execute(s, params)).mappings().fetchone()
+
+        if result is None:
+            return None, None
+
+        res = models.Amenity.model_validate(result)
+        return res, sql
+
+    async def amenities_search(
+        self, query_embedding: list[float], similarity_threshold: float, top_k: int
+    ) -> tuple[list[Any], Optional[str]]:
+        async with self.__pool.connect() as conn:
+            sql = """
+                SELECT name, description, location, terminal, category, hour
+                FROM amenities
+                WHERE (embedding <=> :query_embedding) < :similarity_threshold
+                ORDER BY (embedding <=> :query_embedding)
+                LIMIT :top_k
+                """
+            s = text(sql)
+            params = {
+                "query_embedding": query_embedding,
+                "similarity_threshold": similarity_threshold,
+                "top_k": top_k,
+            }
+            results = (await conn.execute(s, params)).mappings().fetchall()
+
+        res = [r for r in results]
+        return res, sql
+
+    async def get_flight(
+        self, flight_id: int
+    ) -> tuple[Optional[models.Flight], Optional[str]]:
+        async with self.__pool.connect() as conn:
+            sql = """
+                SELECT * FROM flights
+                  WHERE id = :flight_id
+                """
+            s = text(sql)
+            params = {"flight_id": flight_id}
+            result = (await conn.execute(s, params)).mappings().fetchone()
+
+        if result is None:
+            return None, None
+
+        res = models.Flight.model_validate(result)
+        return res, sql
+
+    async def search_flights_by_number(
+        self,
+        airline: str,
+        number: str,
+    ) -> tuple[list[models.Flight], Optional[str]]:
+        async with self.__pool.connect() as conn:
+            sql = """
+                SELECT * FROM flights
+                  WHERE airline = :airline
+                  AND flight_number = :number
+                  LIMIT 10
+                """
+            s = text(sql)
+            params = {
+                "airline": airline,
+                "number": number,
+            }
+            results = (await conn.execute(s, params)).mappings().fetchall()
+
+        res = [models.Flight.model_validate(r) for r in results]
+        return res, sql
+
+    async def search_flights_by_airports(
+        self,
+        date: str,
+        departure_airport: Optional[str] = None,
+        arrival_airport: Optional[str] = None,
+    ) -> tuple[list[models.Flight], Optional[str]]:
+        async with self.__pool.connect() as conn:
+            sql = """
+                SELECT * FROM flights
+                  WHERE (CAST(:departure_airport AS TEXT) IS NULL OR departure_airport ILIKE :departure_airport)
+                  AND (CAST(:arrival_airport AS TEXT) IS NULL OR arrival_airport ILIKE :arrival_airport)
+                  AND departure_time >= CAST(:datetime AS timestamp)
+                  AND departure_time < CAST(:datetime AS timestamp) + interval '1 day'
+                  LIMIT 10
+                """
+            s = text(sql)
+            params = {
+                "departure_airport": departure_airport,
+                "arrival_airport": arrival_airport,
+                "datetime": datetime.strptime(date, "%Y-%m-%d"),
+            }
+
+            results = (await conn.execute(s, params)).mappings().fetchall()
+
+        res = [models.Flight.model_validate(r) for r in results]
+        return res, sql
+
+    async def validate_ticket(
+        self,
+        airline: str,
+        flight_number: str,
+        departure_airport: str,
+        departure_time: str,
+    ) -> tuple[Optional[models.Flight], Optional[str]]:
+        departure_time_datetime = datetime.strptime(departure_time, "%Y-%m-%d %H:%M:%S")
+        async with self.__pool.connect() as conn:
+            sql = """
+                    SELECT * FROM flights
+                    WHERE airline ILIKE :airline
+                    AND flight_number ILIKE :flight_number
+                    AND departure_airport ILIKE :departure_airport
+                    AND departure_time = :departure_time
+                """
+            s = text(sql)
+            params = {
+                "airline": airline,
+                "flight_number": flight_number,
+                "departure_airport": departure_airport,
+                "departure_time": departure_time_datetime,
+            }
+            result = (await conn.execute(s, params)).mappings().fetchone()
+
+        if result is None:
+            return None, None
+        res = models.Flight.model_validate(result)
+        return res, sql
+
+    async def insert_ticket(
+        self,
+        user_id: str,
+        user_name: str,
+        user_email: str,
+        airline: str,
+        flight_number: str,
+        departure_airport: str,
+        arrival_airport: str,
+        departure_time: str,
+        arrival_time: str,
+    ):
+        departure_time_datetime = datetime.strptime(departure_time, "%Y-%m-%d %H:%M:%S")
+        arrival_time_datetime = datetime.strptime(arrival_time, "%Y-%m-%d %H:%M:%S")
+
+        async with self.__pool.connect() as conn:
+            s = text(
+                """
+                INSERT INTO tickets (
+                    user_id,
+                    user_name,
+                    user_email,
+                    airline,
+                    flight_number,
+                    departure_airport,
+                    arrival_airport,
+                    departure_time,
+                    arrival_time
+                ) VALUES (
+                    :user_id,
+                    :user_name,
+                    :user_email,
+                    :airline,
+                    :flight_number,
+                    :departure_airport,
+                    :arrival_airport,
+                    :departure_time,
+                    :arrival_time
+                );
+            """
+            )
+            params = {
+                "user_id": user_id,
+                "user_name": user_name,
+                "user_email": user_email,
+                "airline": airline,
+                "flight_number": flight_number,
+                "departure_airport": departure_airport,
+                "arrival_airport": arrival_airport,
+                "departure_time": departure_time_datetime,
+                "arrival_time": arrival_time_datetime,
+            }
+            result = (await conn.execute(s, params)).mappings()
+            await conn.commit()
+            if not result:
+                raise Exception("Ticket Insertion failure")
+
+    async def list_tickets(
+        self,
+        user_id: str,
+    ) -> tuple[list[Any], Optional[str]]:
+        async with self.__pool.connect() as conn:
+            sql = """
+                SELECT user_name, airline, flight_number, departure_airport, arrival_airport, departure_time, arrival_time FROM tickets
+                WHERE user_id = :user_id
+                """
+            s = text(sql)
+            params = {
+                "user_id": user_id,
+            }
+            results = (await conn.execute(s, params)).mappings().fetchall()
+
+        res = [r for r in results]
+        return res, sql
+
+    async def policies_search(
+        self, query_embedding: list[float], similarity_threshold: float, top_k: int
+    ) -> tuple[list[str], Optional[str]]:
+        async with self.__pool.connect() as conn:
+            sql = """
+                SELECT content
+                FROM policies
+                WHERE (embedding <=> :query_embedding) < :similarity_threshold
+                ORDER BY (embedding <=> :query_embedding)
+                LIMIT :top_k
+                """
+            s = text(sql)
+            params = {
+                "query_embedding": query_embedding,
+                "similarity_threshold": similarity_threshold,
+                "top_k": top_k,
+            }
+            results = (await conn.execute(s, params)).mappings().fetchall()
+
+        res = [r["content"] for r in results]
+        return res, sql
+
+    async def close(self):
+        await self.__pool.dispose()


### PR DESCRIPTION
Create a common `PostgresDatastore` class to encapsulate all the DB query logic based on a given connection pool. Reuse the same logic across AlloyDB & CloudSQL Postgres providers for better code maintainability and less redundancy.