### PR TITLE
docs(source/cloudsql_mysql): update cloudsql_mysql.md to indicate supported maintenance versions

### DIFF
--- a/docs/datastore/cloudsql_mysql.md
+++ b/docs/datastore/cloudsql_mysql.md
@@ -1,5 +1,9 @@
 # Setup and configure Cloud SQL for MySQL
 
+## Supported Cloud SQL Maintenance Versions
+
+This LangChain integration is only supported for Cloud SQL maintenance versions between **MYSQL_8_0_36.R20240401.03_00** and **MYSQL_8_0_36.R20241208.01_00**
+
 ## Before you begin
 
 1. Make sure you have a Google Cloud project and billing is enabled.

--- a/docs/datastore/cloudsql_mysql.md
+++ b/docs/datastore/cloudsql_mysql.md
@@ -1,8 +1,7 @@
 # Setup and configure Cloud SQL for MySQL
 
-## Supported Cloud SQL Maintenance Versions
-
-This LangChain integration is only supported for Cloud SQL maintenance versions between **MYSQL_8_0_36.R20240401.03_00** and **MYSQL_8_0_36.R20241208.01_00**
+> [!NOTE]
+> This LangChain integration is only supported for Cloud SQL maintenance versions between **MYSQL_8_0_36.R20240401.03_00** and **MYSQL_8_0_36.R20241208.01_00**
 
 ## Before you begin
 


### PR DESCRIPTION
Updated integration with this:

https://github.com/googleapis/langchain-google-cloud-sql-mysql-python/pull/104

but have not yet updated the sample app.