### PR TITLE
chore: update model

### DIFF
--- a/llm_demo/orchestrator/orchestrator.py
+++ b/llm_demo/orchestrator/orchestrator.py
@@ -25,7 +25,7 @@ class classproperty:
 
 
 class BaseOrchestrator(ABC):
-    MODEL = "gemini-pro"
+    MODEL = "gemini-2.0-flash-001"
 
     @classproperty
     @abstractmethod


### PR DESCRIPTION
Updates model name since `gemini-pro` seems deprecated now.