### PR TITLE
docs: Update docsite links with the new URL and deeplinks

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -134,7 +134,7 @@ Create a Cloud Build trigger via the UI or `gcloud` with the following specs:
 
 1. Create a Cloud Build private pool
 1. Enable Secret Manager API
-1. Create secret, `db_user` and `db_pass`, with your database user and database password defined [here](https://googleapis.github.io/genai-toolbox/resources/sources/).
+1. Create secret, `db_user` and `db_pass`, with your database user and database password defined [here](https://mcp-toolbox.dev/integrations/).
 
 1. Allow Cloud Build to access secret
 1. Add role Vertex AI User (`roles/aiplatform.user`) to Cloud Build Service

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ First, clone this repository and download the MCP Toolbox binary.
       to download the binary. This involves running the following commands:
       ```bash
       # See the releases page for the latest version
-      export VERSION=0.8.0
+      export VERSION=1.1.0
       curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v$VERSION/linux/amd64/toolbox
       chmod +x toolbox
       ```

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Using the Toolbox as an intermediary offers several advantages:
    agent's ability to leverage it successfully.
 
 Head over to the official [MCP Toolbox
-docs](https://googleapis.github.io/genai-toolbox/getting-started/introduction/)
+docs](https://mcp-toolbox.dev)
 for more details.
 
 ## Deployment
@@ -126,7 +126,7 @@ First, clone this repository and download the MCP Toolbox binary.
 2.  **Download MCP Toolbox binary:**
 
       Follow [these
-      steps](https://googleapis.github.io/genai-toolbox/getting-started/introduction/#installing-the-server)
+      steps](https://mcp-toolbox.dev)
       to download the binary. This involves running the following commands:
       ```bash
       # See the releases page for the latest version
@@ -161,7 +161,7 @@ For local development and testing, you can run the Toolbox server directly from
 your terminal. This is the quickest way to get started.
 
 **For instructions, follow the [guide to running the Toolbox
-locally](https://googleapis.github.io/genai-toolbox/getting-started/introduction/#getting-started).**
+locally](https://mcp-toolbox.dev).**
 
 The basic command will be:
 ```bash
@@ -175,7 +175,7 @@ service on Google Cloud Run. This provides a stable, shareable endpoint for your
 application.
 
 **For instructions, follow the [guide to deploying the Toolbox on Cloud
-Run](https://googleapis.github.io/genai-toolbox/how-to/deploy_toolbox/)**.
+Run](https://mcp-toolbox.dev/documentation/deploy-to/)**.
 
 ### Running the Agentic Application
 
@@ -194,5 +194,5 @@ the MCP Toolbox configuration file.
 Please refer to the [MCP Toolbox documentation][configure] for more information on creating
 and configuring tools.
 
-[toolbox]: (https://googleapis.github.io/genai-toolbox/getting-started/introduction/#getting-started)
-[configure]: (https://googleapis.github.io/genai-toolbox/getting-started/configure/)
+[toolbox]: (https://mcp-toolbox.dev)
+[configure]: (https://mcp-toolbox.dev/documentation/configuration/)

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ break down complex questions into smaller, manageable steps.
 The architecture consists of three main components:
 1. **Application** -- The user-facing agentic app that orchestrates the
    interaction between the user and the agent.
-1. **MCP Toolbox** -- [MCP Toolbox](https://github.com/googleapis/genai-toolbox)
+1. **MCP Toolbox** -- [MCP Toolbox](https://github.com/googleapis/mcp-toolbox)
    is a middleware server that exposes the database operations as a set of
    tools. The LLM agent connects to the Toolbox to execute these tools. This
    provides a secure, scalable, and modular way to manage database interactions.
@@ -131,7 +131,7 @@ First, clone this repository and download the MCP Toolbox binary.
       ```bash
       # See the releases page for the latest version
       export VERSION=0.8.0
-      curl -O https://storage.googleapis.com/genai-toolbox/v$VERSION/linux/amd64/toolbox
+      curl -O https://storage.googleapis.com/mcp-toolbox/v$VERSION/linux/amd64/toolbox
       chmod +x toolbox
       ```
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ First, clone this repository and download the MCP Toolbox binary.
       ```bash
       # See the releases page for the latest version
       export VERSION=0.8.0
-      curl -O https://storage.googleapis.com/mcp-toolbox/v$VERSION/linux/amd64/toolbox
+      curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v$VERSION/linux/amd64/toolbox
       chmod +x toolbox
       ```
 

--- a/docs/database_setup.md
+++ b/docs/database_setup.md
@@ -188,14 +188,14 @@ Your `tools.yaml` file must contain the following sections:
 
     Configure this section with a data source named `my-pg-instance` according to
     the **[official guide on configuring data
-    sources](https://googleapis.github.io/genai-toolbox/resources/sources/)**.
+    sources](https://mcp-toolbox.dev/integrations/)**.
 
 * **[Optional] An `authServices` section**
 
     Only required if you want to enable ticket-related features like booking or
     viewing a user's ticket history. To set it up, add a service named
     `my_google_service` by following the **[`authServices` configuration
-    guide](https://googleapis.github.io/genai-toolbox/resources/authservices/)**.
+    guide](https://mcp-toolbox.dev/documentation/configuration/authentication)**.
 
 * **The `tools` and `toolsets` sections**
 


### PR DESCRIPTION
This PR updates the various links and deeplinks to point to the corresponding page in the new MCP Toolbox docsite.